### PR TITLE
docs: add TDD red green refactor skill pack

### DIFF
--- a/docs/exec-plans/completed/2026-03-24-grw-s05-tdd-skill-pack.md
+++ b/docs/exec-plans/completed/2026-03-24-grw-s05-tdd-skill-pack.md
@@ -1,0 +1,90 @@
+# 2026-03-24-grw-s05-tdd-skill-pack
+
+- Issue ID: `GRW-S05`
+- GitHub Issue: `#7`
+- Status: `Completed`
+- Repository: `git-ranker-workflow`
+- Branch Name: `feat/grw-s05-tdd-skill-pack`
+- Task Slug: `2026-03-24-grw-s05-tdd-skill-pack`
+
+## Problem
+
+기능 구현을 TDD로 반복 수행할 계획이지만, `red`, `green`, `refactor` 각 턴에서 무엇을 만들고 무엇을 금지하는지에 대한 project skill이 없다. 이 상태에서는 테스트 작성, 최소 구현, 리팩터링의 경계가 작업자마다 달라질 수 있다.
+
+## Why Now
+
+backend와 client 저장소에서 앞으로 기능 구현 작업이 이어질 예정이므로, 구현 전에 TDD 턴 기준을 먼저 고정해 두는 편이 낫다. 지금 skill로 분리해 두면 이후 기능 요청에서 같은 절차를 반복 설명하지 않아도 된다.
+
+## Scope
+
+- `red`, `green`, `refactor` skill 작성
+- 각 skill에 목적, trigger, 입력, 출력, 검증, 금지 사항, ownership rule 정의
+- `skills/README.md`에 새 skill pack 등록
+- `docs/product/`에 `GRW-S05` 작업 추가
+- `GRW-S05` 실행/완료 기록 남기기
+
+## Non-scope
+
+- 특정 기능 자체 구현
+- 테스트 프레임워크 선택 강제
+- coverage automation 또는 CI 추가
+- 기존 roadmap 역사 문서 정리
+
+## Write Scope
+
+- `skills/`
+- `docs/product/`
+- `docs/exec-plans/`
+
+## Outputs
+
+- `skills/red/SKILL.md`
+- `skills/green/SKILL.md`
+- `skills/refactor/SKILL.md`
+- `skills/README.md`
+- `skills/authoring-rules.md`
+- `docs/product/harness-roadmap.md`
+- `docs/product/work-item-catalog.md`
+- `GRW-S05` 실행/완료 기록
+
+## Verification
+
+- `find skills -maxdepth 2 -type f | sort`
+  - 결과: `skills/README.md`, `skills/authoring-rules.md`, `skills/red/SKILL.md`, `skills/green/SKILL.md`, `skills/refactor/SKILL.md`를 확인했다.
+- `cat skills/red/SKILL.md`
+  - 결과: red 턴의 산출물을 failing test file 하나로 고정하고 production code 변경 금지를 확인했다.
+- `cat skills/green/SKILL.md`
+  - 결과: green 턴에서 test file 수정 없이 최소 구현으로 targeted test를 green으로 만드는 기준을 확인했다.
+- `cat skills/refactor/SKILL.md`
+  - 결과: refactor 턴에서 test file cleanup은 허용하되 assertion 의미와 behavior contract 변경은 금지하는 기준을 확인했다.
+- `rg -n "GRW-S05|name: red|name: green|name: refactor" docs/product skills docs/exec-plans/completed/2026-03-24-grw-s05-tdd-skill-pack.md`
+  - 결과: 새 skill pack과 skill 이름이 `skills/README.md`, `docs/product/harness-roadmap.md`, `docs/product/work-item-catalog.md`, 완료 기록에 반영된 것을 확인했다.
+
+## Evidence
+
+문서 전용 Issue라 브라우저, 로그, 메트릭 artifact는 필수는 아니다. 대신 검증 명령 결과와 갱신된 source of truth 문서 경로를 exec plan에 남긴다.
+
+## Risks or Blockers
+
+- 현재 skill은 repo-agnostic하게 작성돼 있어, 실제 backend/client 작업에서 반복되는 프레임워크별 패턴은 후속 skill이나 examples로 보완할 수 있다.
+- red/green/refactor 경계를 강하게 잡았기 때문에, 예외 상황이 반복되면 별도 보완 규칙을 추가해야 한다.
+
+## Next Preconditions
+
+- 이후 backend/client 기능 구현 작업에서 이 skill pack을 실제로 사용해 보고 보완 포인트를 수집한다.
+- 반복되는 프레임워크별 예시가 쌓이면 `examples/` 또는 후속 skill pack으로 분리한다.
+
+## Docs Updated
+
+- `skills/README.md`
+- `skills/authoring-rules.md`
+- `skills/red/SKILL.md`
+- `skills/green/SKILL.md`
+- `skills/refactor/SKILL.md`
+- `docs/product/harness-roadmap.md`
+- `docs/product/work-item-catalog.md`
+- `docs/exec-plans/completed/2026-03-24-grw-s05-tdd-skill-pack.md`
+
+## Skill Consideration
+
+이번 Issue는 구현용 공용 TDD 절차를 project skill로 고정하는 작업이다. 이후 실제 기능 작업에서는 이 skill pack을 그대로 재사용하고, 특정 저장소 패턴이 반복될 때만 repo-specific 보조 skill을 추가한다.

--- a/docs/product/harness-roadmap.md
+++ b/docs/product/harness-roadmap.md
@@ -20,31 +20,35 @@
 1. `GRW-01` workflow skeleton과 문서 규칙 만들기
 2. `GRW-02` 현재 readiness 기준선 문서화
 3. `GRW-S01` skill registry와 authoring 규칙 정의
-4. `GRB-01` 백엔드 OpenAPI 계약 생성 기반 만들기
-5. `GRW-03` 백엔드 도메인/운영 문서 수집
-6. `GRC-01` 프런트엔드 계약 타입 단일화
-7. `GRW-04` 프런트엔드 구조/데이터 흐름 문서 수집
-8. `GRW-S02` core planning/parallel-agent skill pack v1
-9. `GRB-02` 백엔드 검증 루프 hardening
-10. `GRC-02` 프런트 lint debt 1차 정리
-11. `GRC-03` 프런트 build/runtime 하네스 친화화
-12. `GRW-05` workflow 표준 검증 런타임 만들기
-13. `GRB-03` 랭킹 조회용 결정적 seed 데이터 지원
-14. `GRC-04` 랭킹 조회 Playwright 하네스 도입
-15. `GRW-06` 랭킹 조회 증거 수집 루프 추가
-16. `GRW-S03` ranking harness execution skill pack v1
-17. `GRW-07` 문서/계약/플랜 freshness 가드레일 추가
-18. `GRW-08` 배지 하네스 계획 문서 작성
-19. `GRW-09` 배치 하네스 계획 문서 작성
-20. `GRW-S04` reliability/batch skill pack v1
+4. `GRW-S05` TDD red-green-refactor skill pack v1
+5. `GRB-01` 백엔드 OpenAPI 계약 생성 기반 만들기
+6. `GRW-03` 백엔드 도메인/운영 문서 수집
+7. `GRC-01` 프런트엔드 계약 타입 단일화
+8. `GRW-04` 프런트엔드 구조/데이터 흐름 문서 수집
+9. `GRW-S02` core planning/parallel-agent skill pack v1
+10. `GRB-02` 백엔드 검증 루프 hardening
+11. `GRC-02` 프런트 lint debt 1차 정리
+12. `GRC-03` 프런트 build/runtime 하네스 친화화
+13. `GRW-05` workflow 표준 검증 런타임 만들기
+14. `GRB-03` 랭킹 조회용 결정적 seed 데이터 지원
+15. `GRC-04` 랭킹 조회 Playwright 하네스 도입
+16. `GRW-06` 랭킹 조회 증거 수집 루프 추가
+17. `GRW-S03` ranking harness execution skill pack v1
+18. `GRW-07` 문서/계약/플랜 freshness 가드레일 추가
+19. `GRW-08` 배지 하네스 계획 문서 작성
+20. `GRW-09` 배치 하네스 계획 문서 작성
+21. `GRW-S04` reliability/batch skill pack v1
 
 ## 바로 다음에 추천하는 작업
 
 1. `GRW-01`
 2. `GRW-S01`
-3. `GRC-01`
+3. `GRW-S05`
+4. `GRC-01`
 
 `GRW-01`을 먼저 권장하는 이유는 이후 모든 문서, exec plan, skill, evidence를 놓을 자리를 먼저 만들어야 하기 때문이다.
+
+`GRW-S05`를 이어서 권장하는 이유는 이후 backend/client 기능 구현 작업을 TDD turn 기준으로 반복 재사용할 수 있기 때문이다.
 
 ## 사용 원칙
 

--- a/docs/product/work-item-catalog.md
+++ b/docs/product/work-item-catalog.md
@@ -123,6 +123,17 @@
 - 산출물: skill index, authoring 규칙 문서
 - 검증: `find skills -maxdepth 2 -type f | sort`, 핵심 문서 내용 확인
 
+### GRW-S05. TDD red-green-refactor skill pack v1
+
+- 저장소: `git-ranker-workflow`
+- 선행조건: `GRW-S01`
+- 권장 write scope: `skills/` 하위, 관련 source of truth 문서
+- 기본 결정: `red`, `green`, `refactor`는 분리된 skill로 유지한다. red turn의 산출물은 failing test file 하나뿐이다. green turn은 test 수정 없이 최소 구현으로 통과시킨다. refactor turn은 green 유지 하에 production/test cleanup을 허용하되 의미 변경은 금지한다.
+- 핵심 작업: `red`, `green`, `refactor` 문서 작성, skill index에 사용 시점 연결
+- 비범위: 특정 기능 구현, 테스트 프레임워크 선택 강제, coverage automation 추가
+- 산출물: TDD skill 3종, 갱신된 skill registry
+- 검증: `find skills -maxdepth 2 -type f | sort`, `cat skills/red/SKILL.md`, `cat skills/green/SKILL.md`, `cat skills/refactor/SKILL.md`, 관련 문서 grep
+
 ### GRW-S02. core planning/parallel-agent skill pack v1
 
 - 저장소: `git-ranker-workflow`

--- a/skills/README.md
+++ b/skills/README.md
@@ -69,7 +69,13 @@ skills/promql-logql-evidence/
 
 ## Registry Status
 
-현재 이 디렉터리에는 authoring 규칙만 있고, 실제 project skill 본문은 아직 추가되지 않았다. 후속 작업에서 아래 skill 후보를 순서대로 채운다.
+현재 등록된 project skill은 아래와 같다.
+
+- `red` (`GRW-S05`): failing test file 하나만 남기는 TDD red turn
+- `green` (`GRW-S05`): test 수정 없이 최소 구현으로 green을 만드는 턴
+- `refactor` (`GRW-S05`): green 유지 하에 구조를 정리하는 refactor 턴
+
+후속 작업에서 아래 skill pack을 순서대로 채운다.
 
 - `GRW-S02`: `issue-to-exec-plan`, `parallel-work-split`, `api-contract-sync`
 - `GRW-S03`: `ranking-read-harness`, `playwright-browser-qa`, `promql-logql-evidence`

--- a/skills/authoring-rules.md
+++ b/skills/authoring-rules.md
@@ -26,6 +26,8 @@
 ## Writing Guidance
 
 - 서두에서 관련 source of truth 문서를 먼저 읽게 한다.
+- 모든 skill에 같은 boilerplate `Read First` 섹션을 반복하지 않는다. 실제로 이 skill에서만 꼭 읽어야 하는 문서가 있을 때만 적는다.
+- `workflow governance`, `authoring rules` 같은 공통 문서는 필요할 때 precondition이나 relevant docs로 간단히 언급하고, 매 skill마다 기계적으로 복붙하지 않는다.
 - 명령은 실제로 반복 실행 가능한 수준으로 구체적으로 적는다.
 - 증거 규칙은 "가능하면"이 아니라 "최소 무엇은 남겨야 한다" 수준으로 적는다.
 - 금지 사항은 모호하게 쓰지 말고, 어떤 우회를 막는지 분명히 적는다.
@@ -34,6 +36,16 @@
 ## File Layout Rules
 
 - 기본 레이아웃은 `skills/<skill-name>/SKILL.md`다.
+- `SKILL.md` 상단에는 가능하면 아래 형태의 YAML frontmatter를 둔다.
+
+```yaml
+---
+name: red
+description: One-line trigger and purpose summary.
+---
+```
+
+- frontmatter를 제외한 본문 구조는 고정 템플릿으로 강제하지 않는다. 대신 required coverage를 빠뜨리지 않는 것이 더 중요하다.
 - 지원 파일은 각 skill 폴더 안에 둔다.
 - 아래 디렉터리는 필요할 때만 추가한다.
   - `templates/`
@@ -52,6 +64,7 @@
 ## Review Checklist
 
 - 이 skill이 반복 가능성이 높은 하나의 흐름에 집중하는가
+- `name`, `description` metadata가 trigger를 충분히 설명하는가
 - 필요한 입력과 선행조건이 빠지지 않았는가
 - 산출물 위치와 required evidence가 명확한가
 - forbidden shortcuts와 ownership rule이 실제 위험을 막는가

--- a/skills/green/SKILL.md
+++ b/skills/green/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: green
+description: Use this skill for the green phase of TDD when a failing test already exists and the goal is to make it pass by changing only production-side code.
+---
+
+# Green Implementation Turn
+
+## Purpose
+
+이미 잠근 failing test를 통과시키는 최소 구현을 만든다. 이 턴의 목적은 설계 정리가 아니라 pass를 만드는 것이다.
+
+## Trigger
+
+- 직전 red turn이 끝나 있고 failing test가 재현 가능하다.
+- 실패 원인이 구현 부재 또는 구현 불일치로 확인됐다.
+- 이제 behavior를 통과시키는 최소 구현이 필요하다.
+
+## Inputs and Preconditions
+
+- red turn에서 만든 failing test file과 명령이 있어야 한다.
+- 테스트가 왜 실패하는지 이해하고 있어야 한다.
+- 현재 작업의 exec plan과 직전 red turn 결과를 이미 확인한 상태여야 한다.
+- 구현 범위가 애매하면 코드를 늘리기 전에 사용자에게 질문한다.
+- 이 턴에서는 test file을 수정하지 않는다.
+
+## Output and Artifact Location
+
+- 산출물은 failing test를 green으로 바꾸는 production-side 변경이다.
+- test file은 수정하지 않는다.
+- 필요한 범위의 production 파일만 바꾼다.
+- 작업 기록에는 어떤 구현 파일이 바뀌었는지와 어떤 명령으로 green을 확인했는지 남긴다.
+
+## Standard Commands
+
+먼저 red를 다시 재현한 뒤, 가장 작은 구현으로 targeted test를 green으로 만든다.
+
+예시:
+
+```bash
+./gradlew test --tests com.gitranker.ranking.RankingServiceTest
+npm test -- ranking-page.test.ts
+npx vitest run src/features/ranking/ranking-page.test.ts
+```
+
+targeted test가 green이 되면, 필요할 때만 인접한 작은 범위의 suite를 추가로 확인한다.
+
+## Required Evidence
+
+- green을 확인한 명령
+- 변경한 production file 목록
+- test file을 수정하지 않았다는 확인
+- 구현이 red에서 잠근 동작만 해결했다는 요약
+
+## Forbidden Shortcuts
+
+- test file을 수정하지 않는다.
+- passing을 위해 assertion, fixture, mock을 뒤로 숨겨 바꾸지 않는다.
+- refactor 성격의 cleanup을 이 턴에 섞지 않는다.
+- 현재 failing test와 무관한 새 동작을 같이 구현하지 않는다.
+- 필요 이상으로 넓은 구조 변경을 하지 않는다.
+
+## Parallel Ownership Rule
+
+- 한 agent는 한 behavior slice의 production 파일 집합만 소유한다.
+- 같은 slice의 red/refactor와 파일 ownership이 겹치면 순서를 나눈다.
+- shared core module을 건드려야 하면 다른 green 작업과 충돌하지 않게 범위를 먼저 고정한다.
+
+## Handoff
+
+refactor 턴으로 넘길 때는 아래를 함께 전달한다.
+
+- green이 된 targeted test 명령
+- 변경한 production file 목록
+- 아직 남아 있는 중복, 냄새, 구조 개선 포인트

--- a/skills/red/SKILL.md
+++ b/skills/red/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: red
+description: Use this skill for the red phase of TDD when the current turn must end with exactly one failing test file and zero production code changes.
+---
+
+# Red Test Turn
+
+## Purpose
+
+한 개의 작은 행동 조각을 실행 가능한 failing test로 고정한다. 이 턴의 목적은 구현이 아니라 기대 동작을 먼저 잠그는 것이다.
+
+## Trigger
+
+- 사용자가 TDD로 시작하자고 요청했다.
+- 현재 slice를 설명하는 failing test가 아직 없다.
+- 다음 단계에서 구현보다 명세 고정이 먼저 필요하다.
+
+## Inputs and Preconditions
+
+- 구현할 동작 slice가 하나로 좁혀져 있어야 한다.
+- 대상 저장소와 현재 테스트 프레임워크를 알고 있어야 한다.
+- 현재 작업의 exec plan과 관련 source of truth 문서를 이미 확인한 상태여야 한다.
+- 기대 동작이나 실패 방식이 애매하면 테스트를 쓰기 전에 사용자에게 질문한다.
+- 이 턴에 섞일 다른 production 변경은 분리되어 있어야 한다.
+
+## Output and Artifact Location
+
+- 산출물은 변경된 test file 하나뿐이다.
+- 새 파일을 만들거나 기존 test file 하나를 수정할 수는 있지만, test file은 하나만 건드린다.
+- production code, config, docs, fixture helper 파일은 바꾸지 않는다.
+- exec plan 또는 작업 기록에는 failing command와 실패 이유 요약을 남긴다.
+
+## Standard Commands
+
+가장 좁은 범위의 기존 테스트 명령을 선택해 red를 확인한다.
+
+예시:
+
+```bash
+./gradlew test --tests com.gitranker.ranking.RankingServiceTest
+npm test -- ranking-page.test.ts
+npx vitest run src/features/ranking/ranking-page.test.ts
+```
+
+실패 원인은 구현 공백이어야 한다. syntax error, import 오류, 환경 미설정 같은 잡음으로 실패하면 red로 간주하지 않는다.
+
+## Required Evidence
+
+- 변경한 test file 경로
+- red를 확인한 명령
+- 기대한 이유로 실패했다는 요약
+- production file이 변경되지 않았다는 확인
+
+## Forbidden Shortcuts
+
+- production code를 수정하지 않는다.
+- test file을 둘 이상 수정하지 않는다.
+- helper, fixture, mock, config 파일을 추가하지 않는다.
+- green을 쉽게 만들기 위해 assertion을 약하게 쓰지 않는다.
+- 여러 행동 조각을 한 red turn에 묶지 않는다.
+
+## Parallel Ownership Rule
+
+- 한 agent는 한 behavior slice와 한 test file만 소유한다.
+- 같은 slice의 green/refactor를 다른 agent가 하고 있다면 동시에 같은 파일을 건드리지 않는다.
+- 공용 test file을 수정해야 하면 먼저 ownership을 명확히 나눈다.
+
+## Handoff
+
+green 턴으로 넘길 때는 아래 세 가지를 함께 전달한다.
+
+- failing test file 경로
+- red를 재현하는 명령
+- 이 테스트가 잠그는 행동 설명 한 줄

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: refactor
+description: Use this skill for the refactor phase of TDD when tests are already green and the goal is to improve code structure without changing behavior.
+---
+
+# Refactor Pass Turn
+
+## Purpose
+
+green을 유지한 채로 구조를 정리한다. 중복 제거, 이름 개선, helper 추출, 테스트 정돈은 가능하지만 외부 동작 의미는 바꾸지 않는다.
+
+## Trigger
+
+- targeted test가 이미 green이다.
+- 현재 구현이나 테스트에 중복, 잡음, 구조적 냄새가 남아 있다.
+- 새 behavior 추가가 아니라 existing behavior 정리가 목적이다.
+
+## Inputs and Preconditions
+
+- targeted test가 green이라는 기준선이 있어야 한다.
+- 현재 behavior contract가 어떤 테스트로 잠겨 있는지 알고 있어야 한다.
+- 현재 작업의 exec plan과 직전 green turn 결과를 이미 확인한 상태여야 한다.
+- 테스트 파일을 건드릴 경우에도 의미 변경 없이 cleanup만 할 것이라는 기준을 먼저 지켜야 한다.
+- assertion 의미를 바꿔야 할 것 같으면 refactor를 멈추고 사용자에게 질문한다.
+
+## Output and Artifact Location
+
+- 산출물은 pass를 유지한 구조 개선이다.
+- production code는 수정할 수 있다.
+- test file도 중복 제거, helper 추출, 이름 정리, setup 정돈처럼 비의미적 cleanup에 한해 수정할 수 있다.
+- 작업 기록에는 어떤 코드 냄새를 줄였는지와 어떤 테스트로 green을 유지했는지 남긴다.
+
+## Standard Commands
+
+리팩터링 전후로 같은 기준의 테스트를 실행해 green 유지 여부를 확인한다.
+
+예시:
+
+```bash
+./gradlew test --tests com.gitranker.ranking.RankingServiceTest
+npm test -- ranking-page.test.ts
+npx vitest run src/features/ranking/ranking-page.test.ts
+```
+
+필요하면 targeted test 외에 인접한 작은 suite를 추가로 확인한다. refactor 턴은 항상 green으로 끝나야 한다.
+
+## Required Evidence
+
+- refactor 후 green을 확인한 명령
+- 변경한 file 목록
+- test file을 수정했다면 "중복 제거", "helper 추출", "가독성 개선"처럼 비의미적 이유 요약
+- behavior나 assertion 의미를 바꾸지 않았다는 확인
+
+## Forbidden Shortcuts
+
+- 새 behavior를 추가하지 않는다.
+- failing test를 통과시키기 위해 기대 결과를 완화하지 않는다.
+- assertion 의미, 시나리오 범위, contract 자체를 바꾸지 않는다.
+- bug fix를 refactor로 위장하지 않는다.
+- 테스트를 red 상태로 둔 채 끝내지 않는다.
+
+## Parallel Ownership Rule
+
+- refactor 대상 파일은 한 번에 한 agent만 소유한다.
+- shared test file을 정리할 때는 그 파일을 건드리는 다른 agent 작업이 끝난 뒤 진행한다.
+- implementation 변경과 test cleanup이 같이 들어가더라도 ownership 범위는 한 behavior slice 안으로 제한한다.
+
+## Handoff
+
+다음 작업으로 넘길 때는 아래를 정리한다.
+
+- green을 유지한 검증 명령
+- 제거한 중복 또는 개선한 구조 포인트
+- 아직 남아 있지만 다음 slice로 넘긴 개선 항목


### PR DESCRIPTION
## 1) 요약
- 무엇이 변경되었나요? 전통 TDD의 `red`, `green`, `refactor` 3개 turn을 project skill로 추가하고, 관련 registry/authoring 규칙과 roadmap/catalog를 갱신했습니다.
- 왜 지금 필요한가요? 이후 backend/client 기능 구현 작업에서 같은 TDD turn 규칙을 반복 설명하지 않고 재사용하기 위해서입니다.

## 2) 연관 이슈
- Closes #7
- 관련 backend/frontend 이슈/PR: workflow PR #8 (`GRW-S01`) 위에 쌓였습니다.

## 3) 문제와 목표
- 문제: red/green/refactor 각 턴의 허용 범위와 금지 사항을 강제하는 project skill이 없었습니다.
- 운영/문서/하네스 관점의 결과: traditional TDD turn을 workflow-owned skill pack으로 고정했습니다.
- 비목표: 특정 기능 구현, 테스트 프레임워크 선택 강제, coverage automation 추가

## 4) 영향 범위
- 변경된 문서 / 디렉터리 / 스크립트: `skills/red/SKILL.md`, `skills/green/SKILL.md`, `skills/refactor/SKILL.md`, `skills/README.md`, `skills/authoring-rules.md`, `docs/product/harness-roadmap.md`, `docs/product/work-item-catalog.md`, `docs/exec-plans/completed/2026-03-24-grw-s05-tdd-skill-pack.md`
- 다른 저장소 영향: 없음
- 계약 / 런타임 / evidence 영향: runtime/contract 변경은 없고, TDD turn rules와 문서 증거 규칙만 추가됩니다.
- 보안 / 권한 영향: 없음

## 5) 검증 증거

| 유형 | 명령어 / 증거 | 결과 |
| --- | --- | --- |
| Docs Structure | <code>find skills -maxdepth 2 -type f &#124; sort</code> | <code>skills/red/SKILL.md</code>, <code>skills/green/SKILL.md</code>, <code>skills/refactor/SKILL.md</code> 포함 확인 |
| Policy / Index | <code>cat skills/red/SKILL.md</code>, <code>cat skills/green/SKILL.md</code>, <code>cat skills/refactor/SKILL.md</code> | red/green/refactor turn 경계와 금지 사항 확인 |
| Generated / Runtime | <code>rg -n "GRW-S05&#124;name: red&#124;name: green&#124;name: refactor" docs/product skills docs/exec-plans/completed/2026-03-24-grw-s05-tdd-skill-pack.md</code> | skill 이름과 source of truth 반영 확인 |
| GitHub Flow | <code>gh issue create</code>, <code>gh pr create --base feat/grw-s01-skill-registry</code> | Issue #7, PR #9 생성 |

## 6) source of truth 반영
- 업데이트한 문서: `skills/README.md`, `skills/authoring-rules.md`, `skills/red/SKILL.md`, `skills/green/SKILL.md`, `skills/refactor/SKILL.md`, `docs/product/harness-roadmap.md`, `docs/product/work-item-catalog.md`, `docs/exec-plans/completed/2026-03-24-grw-s05-tdd-skill-pack.md`
- 업데이트하지 않은 문서와 사유: `docs/plans/git-ranker-harness-issue-pr-roadmap.md`는 역사 문서라 이번 PR 범위에서는 유지했습니다.

## 7) AI 리뷰 메모 (선택)
- Codex: `GRW-S01`과 분리하기 위해 `feat/grw-s01-skill-registry` 위에 별도 커밋/브랜치로 쌓았습니다.
- CodeRabbitAI:

## 8) 리스크 및 롤백
- 리스크: 현재 PR base는 `feat/grw-s01-skill-registry`입니다. `#8` merge 후 `develop`으로 retarget해야 최종 merge 흐름이 깔끔합니다.
- 롤백 계획: commit `5d48085` revert

## 9) 체크리스트
- [x] 연관 이슈가 연결되어 있음
- [x] 검증 결과가 기입되어 있음
- [x] source of truth 문서 반영 여부가 적혀 있음
- [x] 다른 저장소 영향이 있으면 분리 계획 또는 후속 이슈가 적혀 있음
- [x] `develop` 기준 브랜치와 PR 정보가 맞게 기입되어 있음