### PR TITLE
GRB-02 backend verification hardening 완료 기록

### DIFF
--- a/docs/exec-plans/completed/2026-03-26-grb-02-backend-verification-hardening.md
+++ b/docs/exec-plans/completed/2026-03-26-grb-02-backend-verification-hardening.md
@@ -6,7 +6,7 @@
 - Status: `Completed`
 - Repository: `git-ranker`
 - Branch Name: `feat/grb-02-backend-verification-hardening`
-- Commit: `67234f6`
+- Commit: `e31a996`
 - Task Slug: `2026-03-26-grb-02-backend-verification-hardening`
 
 ## Problem

--- a/docs/exec-plans/completed/2026-03-26-grb-02-backend-verification-hardening.md
+++ b/docs/exec-plans/completed/2026-03-26-grb-02-backend-verification-hardening.md
@@ -6,7 +6,7 @@
 - Status: `Completed`
 - Repository: `git-ranker`
 - Branch Name: `feat/grb-02-backend-verification-hardening`
-- Commit: `e31a996`
+- Merged Commit: `64c0541`
 - Task Slug: `2026-03-26-grb-02-backend-verification-hardening`
 
 ## Problem

--- a/docs/exec-plans/completed/2026-03-26-grb-02-backend-verification-hardening.md
+++ b/docs/exec-plans/completed/2026-03-26-grb-02-backend-verification-hardening.md
@@ -1,0 +1,103 @@
+# 2026-03-26-grb-02-backend-verification-hardening
+
+- Issue ID: `GRB-02`
+- GitHub Issue: `alexization/git-ranker#74`
+- GitHub PR: `alexization/git-ranker#75`
+- Status: `Completed`
+- Repository: `git-ranker`
+- Branch Name: `feat/grb-02-backend-verification-hardening`
+- Commit: `67234f6`
+- Task Slug: `2026-03-26-grb-02-backend-verification-hardening`
+
+## Problem
+
+`git-ranker`의 `./gradlew integrationTest`는 Docker daemon이 내려가 있으면 Testcontainers 초기화 단계에서 바로 `ContainerFetchException`과 `DockerClientProviderStrategy` 예외를 내고 실패한다. 현재 출력만으로는 환경 문제인지 코드 회귀인지 빠르게 구분하기 어렵다.
+
+## Why Now
+
+`GRB-02`는 backend 검증 루프를 하네스 친화적으로 만드는 작업이다. 이후 `GRW-05` 표준 검증 런타임과 ranking harness 검증이 안정적으로 동작하려면 Docker 의존 통합 테스트가 fail-fast 하면서도 원인을 명확히 드러내야 한다.
+
+## Scope
+
+- Docker preflight를 `integrationTest` 실행 전에 추가
+- Docker 미가동/미설치 상황에서 명확한 실패 메시지 제공
+- unit, coverage, integration 검증 절차를 backend 문서에 정리
+- 실제 로컬 환경에서 unit/coverage와 integration 경로를 재검증
+
+## Non-scope
+
+- 비즈니스 기능 변경
+- Testcontainers 기반 통합 테스트 구조 전면 리팩터링
+- workflow 런타임 또는 CI 파이프라인 변경
+
+## Write Scope
+
+- `git-ranker` Gradle/test/doc 관련 파일
+- `docs/exec-plans/`
+
+## Outputs
+
+- Docker preflight Gradle task 또는 동등한 fail-fast 실행 경로
+- preflight 메시지를 뒷받침하는 테스트 자산
+- backend 검증 절차 문서
+- `GRB-02` 실행 기록
+
+현재 산출물:
+
+- `git-ranker/build.gradle`의 `verifyDockerAvailable`, `integrationTest` 연결
+- `git-ranker/src/test/java/com/gitranker/api/testsupport/DockerPreflightCheck.java`
+- `git-ranker/src/test/java/com/gitranker/api/testsupport/DockerPreflightMain.java`
+- `git-ranker/src/test/java/com/gitranker/api/testsupport/DockerPreflightCheckTest.java`
+- `git-ranker/README.md`의 verification 절차 섹션
+
+## Verification
+
+- `docker version`으로 현재 Docker daemon 상태 확인
+- `./gradlew test jacocoTestCoverageVerification`
+- `./gradlew integrationTest`
+- Docker 미가동 환경에서 preflight 실패 메시지 확인
+
+결과 요약:
+
+- `docker version`: OrbStack context `orbstack`, server API `1.51` 확인
+- `./gradlew test --tests "com.gitranker.api.testsupport.DockerPreflightCheckTest"`: 성공
+- `./gradlew test jacocoTestCoverageVerification`: 성공
+- `./gradlew verifyDockerAvailable`:
+  - Docker 미기동 상태: 명확한 fail-fast 메시지 확인
+  - Docker 기동 상태: `Docker preflight passed. context=orbstack serverApiVersion=1.51`
+- `./gradlew integrationTest`:
+  - Docker 미기동 상태: Testcontainers 진입 전 preflight 단계에서 실패
+  - Docker 기동 상태: 성공
+
+## Evidence
+
+작업 중 수집한 명령 결과 요약과 문서 갱신 경로를 남긴다. 브라우저, 로그, 메트릭 artifact는 이번 Issue 범위가 아니다.
+
+- baseline 확인:
+  - `docker version` -> daemon 연결 실패
+  - `./gradlew integrationTest` -> `ContainerFetchException`, `DockerClientProviderStrategy`
+- 변경 후 확인:
+  - `./gradlew verifyDockerAvailable` -> Docker 미기동 시 원인/다음 단계가 포함된 fail-fast 메시지 출력
+  - `./gradlew integrationTest` -> Docker 미기동 시 `verifyDockerAvailable` 단계에서 즉시 실패
+  - `docker version` -> OrbStack 실행 후 server 연결 성공
+  - `./gradlew verifyDockerAvailable` -> 성공
+  - `./gradlew integrationTest` -> 성공
+
+## Risks or Blockers
+
+- 로컬 Docker context 종류에 따라 실패 문구 일부가 다를 수 있다.
+- `docker version --format "{{.Server.APIVersion}}"`를 지원하지 않는 매우 오래된 Docker CLI는 별도 보정이 필요할 수 있다.
+
+## Next Preconditions
+
+- `GRW-05`: backend integration preflight를 표준 runtime 검증 순서에 연결
+- `GRB-03`: 결정적 seed 검증 시 통합 테스트 환경 전제조건으로 재사용
+
+## Docs Updated
+
+- `docs/exec-plans/completed/2026-03-26-grb-02-backend-verification-hardening.md`
+- `git-ranker/README.md`
+
+## Skill Consideration
+
+Docker preflight와 unit/coverage/integration 분리 절차는 Spring Boot 검증 루프에서 반복될 가능성이 높다. 이번 작업 결과는 이후 project-specific verification skill이나 runtime runbook 입력으로 재사용할 수 있다.


### PR DESCRIPTION
## 1) 요약
- `GRB-02` backend 작업의 검증 결과와 PR/commit 정보를 workflow exec plan 완료 문서로 반영했습니다.
- workflow 저장소의 `git-ranker` submodule 포인터를 backend branch commit `67234f6`로 갱신했습니다.

## 2) 연관 이슈
- Closes #20
- 관련 backend/frontend 이슈/PR: `alexization/git-ranker#74`, `alexization/git-ranker#75`

## 3) 문제와 목표
- 문제: backend에서 `GRB-02`를 구현해도 workflow source of truth에 완료 기록과 검증 결과가 남지 않으면 후속 하네스 작업이 현재 전제조건을 추적하기 어렵습니다.
- 운영/문서/하네스 관점의 결과: `GRB-02` exec plan이 완료 문서로 승격되고, backend PR/commit/verification 결과가 workflow에서 참조 가능해집니다.
- 비목표: backend 코드 추가 변경, workflow runtime 구현, freshness automation 추가

## 4) 영향 범위
- 변경된 문서 / 디렉터리 / 스크립트: `docs/exec-plans/completed/2026-03-26-grb-02-backend-verification-hardening.md`, `git-ranker` submodule pointer
- 다른 저장소 영향: `git-ranker` PR `#75`를 참조합니다.
- 계약 / 런타임 / evidence 영향: backend Docker preflight와 verification evidence가 완료 문서에 연결됩니다.
- 보안 / 권한 영향: 없음

## 5) 검증 증거

| 유형 | 명령어 / 증거 | 결과 |
| --- | --- | --- |
| Docs Structure | `sed -n "1,260p" docs/exec-plans/completed/2026-03-26-grb-02-backend-verification-hardening.md` | 완료 문서의 상태, PR, commit, verification 결과 반영 확인 |
| Policy / Index | `git status --short`, `git diff --stat` | exec plan 완료 문서와 submodule pointer만 변경됨 확인 |
| Generated / Runtime | `git-ranker`: `./gradlew test jacocoTestCoverageVerification`, `./gradlew verifyDockerAvailable`, `./gradlew integrationTest` | 모두 성공. 완료 문서에 요약 반영 |
| GitHub Flow | `gh issue create`, `gh pr create --base develop` | workflow issue/PR 생성 |

## 6) source of truth 반영
- 업데이트한 문서: `docs/exec-plans/completed/2026-03-26-grb-02-backend-verification-hardening.md`
- 업데이트하지 않은 문서와 사유: 다른 source of truth 문서는 이번 작업 범위가 backend verification hardening 기록 정리에 한정되어 추가 수정하지 않았습니다.

## 7) AI 리뷰 메모 (선택)
- Codex: backend PR과 workflow 완료 문서를 분리해 cross-repo 변경 범위를 정리함
- CodeRabbitAI: 미실행

## 8) 리스크 및 롤백
- 리스크: backend PR head commit이 갱신되면 workflow submodule pointer도 후속 동기화가 필요합니다.
- 롤백 계획: workflow 완료 문서와 submodule pointer를 이전 상태로 되돌립니다.

## 9) 체크리스트
- [x] 연관 이슈가 연결되어 있음
- [x] 검증 결과가 기입되어 있음
- [x] source of truth 문서 반영 여부가 적혀 있음
- [x] 다른 저장소 영향이 있으면 분리 계획 또는 후속 이슈가 적혀 있음
- [x] `develop` 기준 브랜치와 PR 정보가 맞게 기입되어 있음