### PR TITLE
[Task] GRW-11 하네스 시스템 맵과 GitHub 본문 가드레일 정리

### DIFF
--- a/.codex/skills/issue-to-exec-plan/SKILL.md
+++ b/.codex/skills/issue-to-exec-plan/SKILL.md
@@ -41,13 +41,17 @@ description: Use this skill when a roadmap item or GitHub issue must be turned i
 ```bash
 rg -n "GRW-S02|GRC-04|GRB-02" docs/product docs/exec-plans
 find docs/exec-plans/active docs/exec-plans/completed -maxdepth 1 -type f | sort
-gh issue create --repo <owner>/<target-repo> --title "[Task] <issue-id> ..."
+cp .codex/skills/issue-to-exec-plan/templates/github-issue-body.md /tmp/<issue-id>-issue-body.md
+gh issue create --repo <owner>/<target-repo> --title "[Task] <issue-id> ..." --body-file /tmp/<issue-id>-issue-body.md
+gh issue view --repo <owner>/<target-repo> <issue-number> --json body
 git checkout -b feat/grw-s02-core-planning-skill-pack
 ```
 
 명령 자체보다 중요한 것은 "어떤 문서를 읽고 어떤 범위를 고정했는지"를 exec plan에 남기는 것이다.
 
 `gh issue create`의 `--repo`는 항상 대상 저장소와 맞아야 한다. 예를 들어 `GRW-*`는 `alexization/git-ranker-workflow`, `GRB-*`는 `alexization/git-ranker`, `GRC-*`는 `alexization/git-ranker-client`를 쓴다.
+
+workflow 저장소에서 멀티라인 Issue 본문을 만들 때는 `.codex/skills/issue-to-exec-plan/templates/github-issue-body.md`를 복사해 채운다. shell 인라인 `--body`, escaped `\n`, `$'...'` 문자열은 줄바꿈이 깨질 수 있으므로 쓰지 않는다.
 
 ## Required Evidence
 
@@ -65,6 +69,8 @@ git checkout -b feat/grw-s02-core-planning-skill-pack
 - verification을 `문서 확인`, `테스트 실행`처럼 추상적으로 쓰지 않는다.
 - 선행조건이 불명확한데 `Ready` 또는 `In Progress`로 올리지 않는다.
 - 애매한 요구사항을 임의 해석해 plan 본문에 박지 않는다.
+- 멀티라인 GitHub Issue 본문을 `gh issue create --body '...'` 또는 escaped `\n` 문자열로 직접 보내지 않는다.
+- Issue 생성 후 `gh issue view --json body` 확인 없이 줄바꿈이 정상이라고 가정하지 않는다.
 
 ## Parallel Ownership Rule
 

--- a/.codex/skills/issue-to-exec-plan/templates/github-issue-body.md
+++ b/.codex/skills/issue-to-exec-plan/templates/github-issue-body.md
@@ -1,0 +1,42 @@
+## 요청 유형
+<request-type>
+
+## 대상 저장소
+<target-repo>
+
+## 문제 정의
+<problem>
+
+## 왜 지금 필요한가요?
+<why-now>
+
+## 기대 결과 / 완료 조건
+- [ ] <outcome-1>
+- [ ] <outcome-2>
+
+## 범위
+- <scope-1>
+- <scope-2>
+
+## 비범위
+- <non-scope-1>
+- <non-scope-2>
+
+## Write Scope
+- `<path-or-dir-1>`
+- `<path-or-dir-2>`
+
+## Context / Source of Truth
+- `<doc-or-path-1>`
+- `<doc-or-path-2>`
+
+## Verification Contract / 검증 계획
+- `<command-or-check-1>`
+- `<command-or-check-2>`
+
+## 독립 리뷰 기대사항
+- <review-expectation-1>
+- <review-expectation-2>
+
+## Open Questions / Blockers
+- <open-question-or-blocker>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,12 +23,23 @@
 
 ## 6) Verification Contract
 
-| 항목 | 명령 / 확인 방법 | 결과 |
-| --- | --- | --- |
-| Docs / Policy | `미기입 시 사유 작성` | |
-| Type / Lint / Test / Build | `미기입 시 사유 작성` | |
-| Manual Check | `미기입 시 사유 작성` | |
-| 기타 작업별 계약 | `미기입 시 사유 작성` | |
+`Verification Contract`는 아래 section block 형식으로 작성합니다. 각 block에는 `Command / Check`와 `Result`를 기록합니다.
+
+### Docs / Policy
+- Command / Check:
+- Result:
+
+### Type / Lint / Test / Build
+- Command / Check:
+- Result:
+
+### Manual Check
+- Command / Check:
+- Result:
+
+### Other Task-Specific Contract
+- Command / Check:
+- Result:
 
 ## 7) Independent Review
 - Implementer:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,23 +23,45 @@
 
 ## 6) Verification Contract
 
-`Verification Contract`는 아래 section block 형식으로 작성합니다. 각 block에는 `Command / Check`와 `Result`를 기록합니다.
+`Verification Contract`는 카테고리별 section 아래에 check block을 나눠 작성합니다.
+성공한 검증은 `Final Status`와 핵심 `Evidence`만 짧게 적고, 실패, 재시도, 예외가 있었던 경우에만 `Failure / Exception`에 서술합니다.
+검증이 여러 개면 같은 `####` block을 복제해 항목별로 구분합니다.
 
 ### Docs / Policy
+
+#### Check Item
+- Name:
 - Command / Check:
-- Result:
+- Final Status: `PASS | N/A | FAIL | BLOCKED`
+- Evidence:
+- Failure / Exception:
 
 ### Type / Lint / Test / Build
+
+#### Check Item
+- Name:
 - Command / Check:
-- Result:
+- Final Status: `PASS | N/A | FAIL | BLOCKED`
+- Evidence:
+- Failure / Exception:
 
 ### Manual Check
+
+#### Check Item
+- Name:
 - Command / Check:
-- Result:
+- Final Status: `PASS | N/A | FAIL | BLOCKED`
+- Evidence:
+- Failure / Exception:
 
 ### Other Task-Specific Contract
+
+#### Check Item
+- Name:
 - Command / Check:
-- Result:
+- Final Status: `PASS | N/A | FAIL | BLOCKED`
+- Evidence:
+- Failure / Exception:
 
 ## 7) Independent Review
 - Implementer:
@@ -53,7 +75,7 @@
 - 업데이트하지 않은 문서와 사유:
 
 ## 9) Feedback / Guardrail Follow-up
-- 이번 작업에서 드러난 실패 또는 취약 지점:
+- 이번 작업에서 실제로 발생한 실패 / 예외 / 취약 지점:
 - 새 guardrail 후보:
 - 후속 Issue 또는 TODO:
 
@@ -65,7 +87,7 @@
 - [ ] 연결된 Issue가 있다
 - [ ] Scope / Out of Scope가 적혀 있다
 - [ ] Write Scope가 적혀 있다
-- [ ] Verification 결과가 기입되어 있다
+- [ ] Verification 최종 상태와 예외가 기입되어 있다
 - [ ] Implementer와 Reviewer가 분리되어 있다
 - [ ] Source of Truth 반영 여부가 적혀 있다
 - [ ] Feedback 또는 후속 guardrail 후보가 적혀 있다

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,9 +7,10 @@
 1. [AGENTS.md](../AGENTS.md)
 2. [PLANS.md](../PLANS.md)
 3. [docs/architecture/control-plane-map.md](architecture/control-plane-map.md)
-4. [docs/operations/workflow-governance.md](operations/workflow-governance.md)
-5. [docs/product/harness-roadmap.md](product/harness-roadmap.md)
-6. [docs/product/work-item-catalog.md](product/work-item-catalog.md)
+4. [docs/architecture/harness-system-map.md](architecture/harness-system-map.md)
+5. [docs/operations/workflow-governance.md](operations/workflow-governance.md)
+6. [docs/product/harness-roadmap.md](product/harness-roadmap.md)
+7. [docs/product/work-item-catalog.md](product/work-item-catalog.md)
 
 ## 디렉터리 맵
 
@@ -26,5 +27,5 @@
 
 ## 우선순위
 
-- 원본 로드맵 문서는 이관 전 기준과 배경을 보관하는 참고 자료다.
+- 역사 roadmap 문서는 이관 전 기준과 배경을 보관하는 참고 자료다.
 - 현재 작업 지시와 운영 기준은 `docs/` 아래 문서를 우선한다.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -5,4 +5,5 @@
 현재 기준 문서:
 
 - [control-plane-map.md](control-plane-map.md)
+- [harness-system-map.md](harness-system-map.md)
 - [frontend-route-map.md](frontend-route-map.md)

--- a/docs/architecture/control-plane-map.md
+++ b/docs/architecture/control-plane-map.md
@@ -18,13 +18,15 @@
 ## 읽기 우선순위
 
 1. 루트 인덱스: `AGENTS.md`, `PLANS.md`
-2. 공통 운영 규칙: `docs/operations/workflow-governance.md`
-3. 실행 순서와 작업 카탈로그: `docs/product/*.md`
-4. 해당 작업의 exec plan: `docs/exec-plans/active/*.md` 또는 `docs/exec-plans/completed/*.md`
-5. 도메인/운영 상세 문서
+2. 아키텍처 기준: `docs/architecture/control-plane-map.md`, `docs/architecture/harness-system-map.md`
+3. 공통 운영 규칙: `docs/operations/workflow-governance.md`
+4. 실행 순서와 작업 카탈로그: `docs/product/*.md`
+5. 해당 작업의 exec plan: `docs/exec-plans/active/*.md` 또는 `docs/exec-plans/completed/*.md`
+6. 도메인/운영 상세 문서
 
 ## 이관 원칙
 
-- `docs/plans/git-ranker-harness-issue-pr-roadmap.md`는 초기 분해 문서로 유지한다.
+- `docs/references/git-ranker-harness-issue-pr-roadmap.md`는 초기 분해를 보관하는 역사 문서다.
+- 현재 계획 source of truth는 `docs/product/`와 `docs/exec-plans/`에 둔다.
 - 이후 작업 지시는 원칙적으로 `docs/product/`, `docs/operations/`, `docs/exec-plans/`에서 읽는다.
 - 새 문서가 생기면 이 구조를 깨지 않도록 가장 가까운 목적 디렉터리에 추가한다.

--- a/docs/architecture/harness-system-map.md
+++ b/docs/architecture/harness-system-map.md
@@ -38,7 +38,7 @@
 | Request record | 사용자 요청과 초기 분류 결과 | Issue 본문 또는 작업 대화 |
 | Exec plan | scope, non-scope, write scope, verification contract | `docs/exec-plans/` |
 | Context pack | 이번 작업에 허용된 최소 문서와 write scope | exec plan과 후속 policy |
-| Verification report | 실행 명령, 결과, 실패 요약 | exec plan, PR 본문, `.artifacts/` 필요 시 |
+| Verification report | 실행 명령, 최종 상태, 핵심 evidence, 실패/예외 요약 | exec plan, PR 본문, `.artifacts/` 필요 시 |
 | Review verdict | reviewer 승인 또는 수정 요청 | PR 본문, review comment, exec plan 요약 |
 | Feedback entry | 반복 실패와 guardrail 승격 여부 | exec plan, 후속 policy 또는 ledger |
 

--- a/docs/architecture/harness-system-map.md
+++ b/docs/architecture/harness-system-map.md
@@ -1,0 +1,125 @@
+# Harness System Map
+
+이 문서는 `git-ranker-workflow` 하네스의 architecture-level source of truth다. [docs/product/harness-roadmap.md](../product/harness-roadmap.md)가 작업 순서와 목표를 설명한다면, 이 문서는 각 단계의 책임과 입력/출력과 상태 전이를 정의한다.
+
+## Control Objectives
+
+하네스는 아래 여섯 축을 순서대로 고정하는 것을 목표로 한다.
+
+1. 요청 라우팅
+2. 컨텍스트 최소 공개
+3. 도구 경계와 write scope 통제
+4. 결정론적 검증
+5. 구현 Agent와 review Agent 분리
+6. 실패의 가드레일화
+
+## Planning Boundary
+
+- 현재 planning source of truth는 [docs/product/harness-roadmap.md](../product/harness-roadmap.md), [docs/product/work-item-catalog.md](../product/work-item-catalog.md), [docs/exec-plans/](../exec-plans/README.md)다.
+- 작업 순서와 backlog는 `docs/product/`가, task별 범위와 검증은 `docs/exec-plans/`가 맡는다.
+- 이관 전 전체 분해 문서와 초기 아이디어는 `docs/references/`에 둔다. 역사 문서는 현재 작업 지시를 내리는 planning source가 아니다.
+
+## System Components
+
+| Component | Responsibility | Primary Input | Primary Output |
+| --- | --- | --- | --- |
+| Router | 사용자 요청을 `대화`, `모호한 요청`, `즉시 실행 가능한 작업`으로 분류한다. | 사용자 요청, 상위 운영 규칙 | route decision |
+| Interview | 모호한 요청을 줄여 exec plan으로 고정 가능한 작업으로 만든다. | ambiguous request, source of truth | clarified scope, close-out decision |
+| Context Pack | task type에 맞는 최소 문서와 write scope를 고정한다. | exec plan, task type, source docs | bounded context pack |
+| Implementer | 허용된 저장소와 파일 범위 안에서 변경을 만든다. | context pack, exec plan | diff, change notes |
+| Verification | 명시된 verification contract를 실행하고 pass/fail을 기록한다. | diff, verification contract | verification report |
+| Reviewer | 구현과 분리된 관점으로 diff와 검증 결과를 검토한다. | diff, verification report, exec plan | review verdict |
+| Feedback | 실패와 취약 지점을 guardrail 후보로 분류하고 close-out을 남긴다. | review verdict, failure notes, exec plan | feedback entry, next follow-up |
+
+## Canonical Artifacts
+
+| Artifact | Description | Canonical Location |
+| --- | --- | --- |
+| Request record | 사용자 요청과 초기 분류 결과 | Issue 본문 또는 작업 대화 |
+| Exec plan | scope, non-scope, write scope, verification contract | `docs/exec-plans/` |
+| Context pack | 이번 작업에 허용된 최소 문서와 write scope | exec plan과 후속 policy |
+| Verification report | 실행 명령, 결과, 실패 요약 | exec plan, PR 본문, `.artifacts/` 필요 시 |
+| Review verdict | reviewer 승인 또는 수정 요청 | PR 본문, review comment, exec plan 요약 |
+| Feedback entry | 반복 실패와 guardrail 승격 여부 | exec plan, 후속 policy 또는 ledger |
+
+## Canonical State Machine
+
+### Happy Path
+
+`Received -> Routed -> Planned -> Context Ready -> Implementing -> Verifying -> Reviewing -> Feedback Pending -> Completed`
+
+### Ambiguity Path
+
+`Received -> Routed -> Interviewing -> Planned`
+
+### Repair Path
+
+`Verifying -> Repairing -> Implementing`
+
+`Reviewing -> Repairing -> Implementing`
+
+### Terminal Non-execution Path
+
+`Routed -> Rejected`
+
+### Canonical States
+
+| State | Entry Criteria | Exit Condition | Next State |
+| --- | --- | --- | --- |
+| `Received` | 사용자 요청이 들어왔다. | Router가 요청 유형을 분류했다. | `Routed` |
+| `Routed` | 요청이 `대화`, `모호한 요청`, `즉시 실행 가능한 작업` 중 하나로 분류됐다. | 대화/거절이면 종료, 모호하면 인터뷰 시작, 실행 가능하면 Issue와 exec plan을 만든다. | `Rejected`, `Interviewing`, `Planned` |
+| `Interviewing` | 요청은 실행 후보지만 범위나 완료 조건이 아직 모호하다. | ambiguity가 줄어 exec plan을 쓸 수 있거나, 더 이상 줄일 수 없다고 판단한다. | `Planned`, `Blocked`, `Rejected` |
+| `Planned` | Issue와 exec plan이 생성되어 scope, non-scope, write scope, verification contract 초안이 잠겼다. | task type에 맞는 context pack과 허용 범위가 확정됐다. | `Context Ready`, `Blocked` |
+| `Context Ready` | 필요한 최소 문서와 write scope가 고정됐다. | Implementer가 변경을 시작하거나, 필요한 source of truth가 부족하다고 판단한다. | `Implementing`, `Interviewing`, `Blocked` |
+| `Implementing` | Implementer가 허용된 범위 안에서 변경을 만든다. | 검증 가능한 diff가 준비되거나, scope drift 또는 외부 blocker가 드러난다. | `Verifying`, `Blocked` |
+| `Verifying` | 결정론적 검증 명령을 실행한다. | 모든 필수 명령이 통과하거나, 실패/환경 blocker가 발생한다. | `Reviewing`, `Repairing`, `Blocked` |
+| `Reviewing` | Reviewer가 diff와 검증 결과를 함께 평가한다. | 승인하거나, 수정 요청을 남기거나, 검토 불가능한 blocker를 선언한다. | `Feedback Pending`, `Repairing`, `Blocked` |
+| `Repairing` | verification 실패나 review 요청으로 재작업이 필요하다. | 재시도 가능한 수정이 준비되거나, 계속 진행할 근거가 사라진다. | `Implementing`, `Blocked`, `Rejected` |
+| `Feedback Pending` | 최종 close-out 전 실패 원인과 guardrail 후보를 정리해야 한다. | feedback이 기록되고 다음 follow-up 여부가 결정됐다. | `Completed` |
+| `Completed` | verification 통과, reviewer 승인, feedback close-out이 모두 끝났다. | 없음 | terminal |
+| `Blocked` | 선행조건 미충족, 외부 의존성, write scope 충돌, source 부족으로 더 진행할 수 없다. | blocker 해소 후 다시 진입하거나 작업을 종료한다. | `Interviewing`, `Planned`, `Context Ready`, terminal |
+| `Rejected` | 대화성 요청, 작업 취소, 범위 밖 요청처럼 실행을 계속하지 않기로 했다. | 없음 | terminal |
+
+## Pass / Fail Semantics
+
+| Stage | Pass | Fail | Required Consequence |
+| --- | --- | --- | --- |
+| Router | 정확히 하나의 route를 선택했고 다음 소유자가 명확하다. | route가 중복되거나 비어 있다. | 편집 작업을 시작하지 않고 intake로 되돌린다. |
+| Interview | scope, non-scope, write scope, 완료 조건을 exec plan에 적을 수 있다. | ambiguity가 남아 실행 조건을 잠글 수 없다. | `Blocked` 또는 `Rejected`로 종료한다. |
+| Context Pack | 최소 문서와 금지 범위가 함께 고정됐다. | source of truth가 부족하거나 불필요한 컨텍스트를 과다 공개했다. | `Interviewing` 또는 `Blocked`로 되돌린다. |
+| Implementer | 허용 write scope 안에서 목표 산출물을 만든다. | scope drift, 무단 cross-repo 변경, 불명확한 요구사항이 발생한다. | `Blocked`로 전환하고 범위를 재정의한다. |
+| Verification | 모든 필수 검증 명령이 통과하고 증거가 남는다. | 명령 실패, 환경 부족, 증거 누락이 있다. | `Repairing` 또는 `Blocked`로 전환한다. |
+| Reviewer | reviewer가 diff, verification report, 남은 리스크를 기준으로 승인한다. | blocking finding, self-approval 시도, 검증과 diff 불일치가 있다. | `Repairing`으로 되돌린다. |
+| Feedback | 실패 분류 또는 `no new guardrail` 판단이 기록됐다. | close-out과 후속 guardrail 판단이 비어 있다. | `Feedback Pending`에 머문다. |
+
+## Stop Conditions
+
+- `Rejected`: 대화성 요청, 범위 밖 요청, 사용자 취소처럼 작업 자체를 진행하지 않는 경우다.
+- `Blocked`: 선행조건 부족, 외부 의존성, 권한 문제, canonical source 부재로 현재 이슈 안에서 더 진행할 수 없는 경우다.
+- `Completed`: verification 통과, reviewer 승인, feedback close-out이 모두 끝난 경우다.
+- `Repairing`은 terminal state가 아니다. 반복 실패가 누적되면 `GRW-15`, `GRW-17`에서 정의할 retry budget과 guardrail 정책에 따라 `Blocked` 또는 후속 Issue로 넘긴다.
+
+## Role Separation Invariants
+
+- Implementer는 자기 결과를 최종 승인할 수 없다.
+- Reviewer는 diff만이 아니라 verification report와 exec plan을 함께 읽어야 한다.
+- verification이 끝나기 전에는 review verdict를 final로 선언할 수 없다.
+- feedback 단계는 성공 경로와 실패 경로 모두에 필요하다. 성공 시에는 `no new guardrail`도 하나의 명시적 판단으로 남긴다.
+- task type별 세부 정책은 후속 Issue가 확장하더라도, `Router -> Interview -> Context Pack -> Implementer -> Verification -> Reviewer -> Feedback` 순서는 바꾸지 않는다.
+
+## Issue / PR Projection
+
+- Issue는 최소한 `Received`에서 `Planned`까지의 상태를 설명해야 한다.
+- exec plan은 `Planned` 상태의 공식 기록이며, 구현을 시작하기 전에 존재해야 한다.
+- PR은 `Implementing` 이후의 산출물과 `Verifying`, `Reviewing`, `Feedback Pending` 증거를 담는 컨테이너다.
+- `Completed` 판정은 PR의 verification 결과와 reviewer verdict, exec plan의 close-out이 함께 있어야 성립한다.
+- 완료된 exec plan은 `docs/exec-plans/completed/`로 옮기고, 후속 Issue가 이 문서를 전제조건으로 참조한다.
+
+## Follow-up Ownership
+
+- `GRW-12`는 `Router`, `Interviewing`, `Rejected` semantics를 세분화한다.
+- `GRW-13`은 `Planned`에서 `Context Ready`로 가는 규칙을 registry로 고정한다.
+- `GRW-14`는 `Context Ready`와 `Implementing` 단계의 tool boundary를 상세화한다.
+- `GRW-15`는 `Verifying`, `Repairing`, `Blocked` semantics와 retry budget을 명시한다.
+- `GRW-16`은 `Reviewing` 단계의 reviewer input과 verdict 규칙을 구체화한다.
+- `GRW-17`은 `Feedback Pending`과 guardrail 승격 규칙을 ledger 형태로 정의한다.

--- a/docs/exec-plans/completed/2026-04-06-grw-11-harness-system-map.md
+++ b/docs/exec-plans/completed/2026-04-06-grw-11-harness-system-map.md
@@ -1,0 +1,122 @@
+# 2026-04-06-grw-11-harness-system-map
+
+- Issue ID: `GRW-11`
+- GitHub Issue: `#31`
+- Status: `Completed`
+- Repository: `git-ranker-workflow`
+- Branch Name: `feat/grw-11-harness-system-map`
+- Task Slug: `2026-04-06-grw-11-harness-system-map`
+
+## Problem
+
+현재 하네스 canonical flow는 roadmap와 work item catalog 수준에서만 표현되어 있어, 시스템 구성요소와 상태 전이와 stop condition을 한 문서에서 읽을 수 없다. 이 상태로 `GRW-12`, `GRW-13`, `GRW-14`, `GRW-15`, `GRW-16`을 이어서 작성하면 같은 흐름을 서로 다른 용어와 완료 조건으로 설명할 위험이 있다.
+
+또한 과거 전체 분해 문서가 `docs/plans/`에 남아 있어, 현재 계획 source of truth인 `docs/product/`와 `docs/exec-plans/` 체계와 위치가 충돌한다. 이번 작업에서는 architecture 문서와 함께 역사 문서 위치도 정리해 planning source를 하나로 고정한다.
+
+작업 중 GitHub issue body를 CLI 인라인 문자열로 만들면 줄바꿈이 literal `\n`로 깨질 수 있다는 운영 문제도 드러났다. 같은 문제가 반복되지 않게 issue/PR 작성 가드레일도 source of truth와 planning skill에 반영해야 한다.
+
+## Why Now
+
+`GRW-11`은 request routing, context pack, tool boundary, verification contract, dual-agent review policy가 공유해야 하는 공통 상태 모델을 제공한다. 상태와 전이 규칙을 먼저 고정하지 않으면 후속 policy 문서가 phase 이름만 공유하고 실제 통제 의미는 달라질 수 있다.
+
+사용자도 `docs/product/harness-roadmap.md`를 기준으로 하네스 구성을 진행하려고 하고 있다. 따라서 과거 roadmap는 source of truth 경계 밖으로 이동시켜 문서 체계를 명확히 해야 한다.
+
+동시에 하네스 작업의 entrypoint인 GitHub issue/PR 본문이 깨지면 이후 exec plan과 review handoff의 품질도 같이 떨어진다. 따라서 body-file 규칙과 생성 직후 검증 루프를 함께 고정한다.
+
+## Scope
+
+- 하네스 시스템 구성요소와 책임을 `docs/architecture/`에 문서화한다.
+- `Router -> Interview -> Context Pack -> Implementer -> Verification -> Reviewer -> Feedback` 흐름의 상태 전이와 역할 분리를 정의한다.
+- stop condition, pass/fail semantics, repair loop의 상위 규칙을 정의한다.
+- 역사 roadmap 문서를 `docs/references/` 체계로 정리하고 관련 인덱스를 갱신한다.
+- GitHub issue/PR 멀티라인 본문 생성 규칙을 `--body-file` 중심으로 정리하고 재사용 템플릿을 추가한다.
+
+## Non-scope
+
+- request routing 세부 정책 정의
+- context pack registry 상세 작성
+- verification 명령 registry와 retry budget 수치 확정
+- backend/frontend 앱 코드 변경
+- skill 신규 작성
+
+## Write Scope
+
+- `docs/architecture/`
+- `docs/README.md`
+- `docs/operations/`
+- `docs/references/`
+- `docs/exec-plans/`
+- `.codex/skills/issue-to-exec-plan/`
+
+## Outputs
+
+- `docs/architecture/harness-system-map.md`
+- 갱신된 architecture/docs/reference 인덱스
+- `docs/references/`로 이관된 역사 roadmap 문서
+- GitHub issue body 재발 방지 규칙과 템플릿
+
+## Working Decisions
+
+- 현재 planning source of truth는 `docs/product/harness-roadmap.md`, `docs/product/work-item-catalog.md`, `docs/exec-plans/`로 고정한다.
+- `GRW-11`은 상태 머신의 상위 semantics만 정의하고, stage별 세부 정책은 후속 Issue에서 확장한다.
+- verification/review 실패는 곧바로 완료 불가를 의미하며, 성공 경로와 실패 경로 모두 feedback 단계에서 close-out 또는 guardrail 후보 판단을 거친다.
+- GitHub issue/PR 멀티라인 본문은 shell 인라인 문자열 대신 body file을 canonical 작성 방식으로 사용한다.
+
+## Verification
+
+- `sed -n '1,260p' docs/architecture/harness-system-map.md`
+  - 결과: 시스템 구성요소, canonical state machine, pass/fail semantics, stop condition, role separation, issue/PR projection이 한 문서에 정리된 것을 확인했다.
+- `rg -n "Router|Interview|Context Pack|Implementer|Verification|Reviewer|Feedback|stop condition|pass/fail|repair loop" docs/architecture docs/README.md docs/references`
+  - 결과: `docs/architecture/harness-system-map.md`에서 canonical flow와 stage semantics가 grep되는 것을 확인했다.
+- `find docs/references -maxdepth 1 -type f | sort`
+  - 결과: `docs/references/git-ranker-harness-issue-pr-roadmap.md`가 history 문서로 존재하는 것을 확인했다.
+- `rg -n "docs/plans/" docs/README.md docs/architecture docs/references`
+  - 결과: 현재 source of truth 인덱스와 reference 인덱스에는 `docs/plans/` 참조가 남아 있지 않은 것을 확인했다.
+- `sed -n '67,92p' docs/operations/workflow-governance.md`
+  - 결과: GitHub issue/PR 본문은 `--body-file`로 만들고 생성 직후 `gh issue view --json body` 또는 `gh pr view --json body`로 확인하는 규칙이 반영된 것을 확인했다.
+- `sed -n '39,78p' .codex/skills/issue-to-exec-plan/SKILL.md`
+  - 결과: `issue-to-exec-plan` skill의 기본 명령이 body file 기반 issue 생성과 body 확인 루프로 바뀐 것을 확인했다.
+- `sed -n '1,220p' .codex/skills/issue-to-exec-plan/templates/github-issue-body.md`
+  - 결과: workflow 저장소 issue 본문을 파일로 작성할 때 바로 복사해 쓸 수 있는 템플릿이 추가된 것을 확인했다.
+- 문서 링크 검토
+  - 결과: `docs/README.md`, `docs/architecture/control-plane-map.md`, `docs/references/README.md`가 새 architecture 문서와 history 문서 위치를 올바르게 가리키는 것을 확인했다.
+
+## Evidence
+
+문서 작업이므로 별도 artifact는 만들지 않는다. 대신 아래를 근거로 남긴다.
+
+- 시스템 맵 문서에서 정의한 canonical state와 transition
+- planning source of truth와 historical reference의 분리 결과
+- GitHub issue body 재발 방지 규칙과 템플릿
+- verification 명령 요약
+
+## Risks or Blockers
+
+- verification contract의 retry budget 수치와 repair loop 최대 횟수는 `GRW-15`에서 더 구체화해야 한다.
+- ambiguity interview 종료 기준은 `GRW-12`에서 세부화해야 하므로 이번 문서는 상위 상태 의미만 다룬다.
+
+## Next Preconditions
+
+- `GRW-12`: 요청 라우팅과 ambiguity interview 정책 정의
+- `GRW-13`: context pack registry와 task-to-context 매핑 정의
+- `GRW-14`: tool boundary matrix와 write scope 거버넌스 정의
+- `GRW-15`: verification contract registry와 repair loop 기준 정의
+- `GRW-16`: dual-agent review policy 정의
+- `GRW-17`: failure-to-guardrail feedback loop 정의
+
+## Docs Updated
+
+- `docs/architecture/harness-system-map.md`
+- `docs/architecture/control-plane-map.md`
+- `docs/architecture/README.md`
+- `docs/README.md`
+- `docs/operations/workflow-governance.md`
+- `docs/references/README.md`
+- `docs/references/git-ranker-harness-issue-pr-roadmap.md`
+- `.codex/skills/issue-to-exec-plan/SKILL.md`
+- `.codex/skills/issue-to-exec-plan/templates/github-issue-body.md`
+- `docs/exec-plans/completed/2026-04-06-grw-11-harness-system-map.md`
+
+## Skill Consideration
+
+이번 작업은 신규 skill을 만드는 단계는 아니다. 다만 상태 머신이 고정되면 후속 `GRW-S06`, `GRW-S07`, `GRW-S08`, `GRW-S09`가 각각 어느 transition을 자동화하는지 더 명확해진다. 이번 턴에서는 기존 `issue-to-exec-plan` skill에 issue body 생성 가드레일만 추가했다.

--- a/docs/exec-plans/completed/2026-04-06-grw-11-harness-system-map.md
+++ b/docs/exec-plans/completed/2026-04-06-grw-11-harness-system-map.md
@@ -30,6 +30,7 @@
 - stop condition, pass/fail semantics, repair loop의 상위 규칙을 정의한다.
 - 역사 roadmap 문서를 `docs/references/` 체계로 정리하고 관련 인덱스를 갱신한다.
 - GitHub issue/PR 멀티라인 본문 생성 규칙을 `--body-file` 중심으로 정리하고 재사용 템플릿을 추가한다.
+- PR template의 `6) Verification Contract`를 section block 형식으로 정리한다.
 
 ## Non-scope
 
@@ -54,6 +55,7 @@
 - 갱신된 architecture/docs/reference 인덱스
 - `docs/references/`로 이관된 역사 roadmap 문서
 - GitHub issue body 재발 방지 규칙과 템플릿
+- pipe-safe PR verification contract template
 
 ## Working Decisions
 
@@ -61,6 +63,7 @@
 - `GRW-11`은 상태 머신의 상위 semantics만 정의하고, stage별 세부 정책은 후속 Issue에서 확장한다.
 - verification/review 실패는 곧바로 완료 불가를 의미하며, 성공 경로와 실패 경로 모두 feedback 단계에서 close-out 또는 guardrail 후보 판단을 거친다.
 - GitHub issue/PR 멀티라인 본문은 shell 인라인 문자열 대신 body file을 canonical 작성 방식으로 사용한다.
+- PR의 verification contract는 section block 형식을 canonical으로 사용한다.
 
 ## Verification
 
@@ -73,7 +76,9 @@
 - `rg -n "docs/plans/" docs/README.md docs/architecture docs/references`
   - 결과: 현재 source of truth 인덱스와 reference 인덱스에는 `docs/plans/` 참조가 남아 있지 않은 것을 확인했다.
 - `sed -n '67,92p' docs/operations/workflow-governance.md`
-  - 결과: GitHub issue/PR 본문은 `--body-file`로 만들고 생성 직후 `gh issue view --json body` 또는 `gh pr view --json body`로 확인하는 규칙이 반영된 것을 확인했다.
+  - 결과: GitHub issue/PR 본문은 `--body-file`로 만들고, PR verification contract는 section block 형식으로 작성하며, 생성 직후 `gh issue view --json body` 또는 `gh pr view --json body`로 확인하는 규칙이 반영된 것을 확인했다.
+- `sed -n '1,260p' .github/PULL_REQUEST_TEMPLATE.md`
+  - 결과: `6) Verification Contract`가 section block 형식으로 정리된 것을 확인했다.
 - `sed -n '39,78p' .codex/skills/issue-to-exec-plan/SKILL.md`
   - 결과: `issue-to-exec-plan` skill의 기본 명령이 body file 기반 issue 생성과 body 확인 루프로 바뀐 것을 확인했다.
 - `sed -n '1,220p' .codex/skills/issue-to-exec-plan/templates/github-issue-body.md`
@@ -88,6 +93,7 @@
 - 시스템 맵 문서에서 정의한 canonical state와 transition
 - planning source of truth와 historical reference의 분리 결과
 - GitHub issue body 재발 방지 규칙과 템플릿
+- pipe-safe PR verification contract template
 - verification 명령 요약
 
 ## Risks or Blockers
@@ -111,6 +117,7 @@
 - `docs/architecture/README.md`
 - `docs/README.md`
 - `docs/operations/workflow-governance.md`
+- `.github/PULL_REQUEST_TEMPLATE.md`
 - `docs/references/README.md`
 - `docs/references/git-ranker-harness-issue-pr-roadmap.md`
 - `.codex/skills/issue-to-exec-plan/SKILL.md`

--- a/docs/operations/workflow-governance.md
+++ b/docs/operations/workflow-governance.md
@@ -68,6 +68,11 @@
 
 - 작업 시작 전 대상 저장소에 `gh issue create`로 이슈를 만든다.
 - 이슈와 PR 본문은 대상 저장소의 Issue/PR template 형식을 따른다.
+- 멀티라인 GitHub 본문은 shell 인라인 `--body`, escaped `\n`, `$'...'` 문자열로 직접 만들지 않는다.
+- GitHub 본문은 먼저 파일로 작성한 뒤 `gh issue create --body-file <path>` 또는 `gh pr create --body-file <path>`로 보낸다.
+- workflow 저장소 Issue 본문은 `.codex/skills/issue-to-exec-plan/templates/github-issue-body.md`를 복사해 채운다.
+- workflow 저장소 PR 본문은 `.github/PULL_REQUEST_TEMPLATE.md`를 복사한 임시 파일을 기준으로 채운다.
+- 생성 직후에는 `gh issue view --json body` 또는 `gh pr view --json body`로 본문이 예상한 줄바꿈과 섹션을 유지하는지 확인한다.
 - Issue template은 최소한 `문제`, `왜 지금`, `범위/비범위`, `write scope`, `context source`, `verification plan`, `open questions`를 포함해야 한다.
 - PR template은 최소한 `연결된 issue`, `범위/비범위`, `write scope`, `verification 결과`, `독립 review 결과`, `feedback follow-up`, `문서 반영`, `리스크`를 포함해야 한다.
 - 커밋 메시지는 항상 루트의 `.gitmessage.ko.txt` 형식을 따른다.
@@ -79,10 +84,11 @@
 현재 기준 실행 순서:
 
 1. 대상 저장소의 `develop` 최신 상태를 기준으로 worktree 또는 branch를 만든다.
-2. `gh issue create`로 대상 저장소 이슈를 만든다.
+2. body file을 준비한 뒤 `gh issue create --body-file ...`로 대상 저장소 이슈를 만든다.
 3. 이슈 번호를 브랜치명과 exec plan에 연결한다.
-4. 작업 후 `gh pr create --base develop`로 PR을 연다.
-5. PR 본문에 검증 결과, 독립 review 결과, 문서 반영 여부, 남은 리스크를 채운다.
+4. 작업 후 PR body file을 준비하고 `gh pr create --base develop --body-file ...`로 PR을 연다.
+5. 생성 직후 `gh issue view --json body` 또는 `gh pr view --json body`로 본문 렌더링을 확인한다.
+6. PR 본문에 검증 결과, 독립 review 결과, 문서 반영 여부, 남은 리스크를 채운다.
 
 ## 문서, SKILL, exec plan의 역할
 

--- a/docs/operations/workflow-governance.md
+++ b/docs/operations/workflow-governance.md
@@ -34,7 +34,7 @@
 - 이번 PR의 범위와 비범위
 - write scope
 - 산출물
-- 검증 명령과 결과
+- 검증 명령, 최종 상태, 핵심 evidence
 - 독립 review 결과
 - feedback 또는 후속 guardrail 후보
 - 남은 리스크
@@ -44,7 +44,7 @@
 
 하네스 관련 PR에서는 가능하면 아래 증거를 남긴다.
 
-- 명령 실행 결과 요약
+- 명령 실행 결과 요약 또는 artifact 위치
 - 브라우저 증거: screenshot, trace, video
 - 로그 증거: LogQL 결과 또는 로그 요약
 - 메트릭 증거: PromQL 결과 또는 지표 캡처
@@ -71,7 +71,8 @@
 - GitHub 본문은 먼저 파일로 작성한 뒤 `gh issue create --body-file <path>` 또는 `gh pr create --body-file <path>`로 보낸다.
 - workflow 저장소 Issue 본문은 `.codex/skills/issue-to-exec-plan/templates/github-issue-body.md`를 복사해 채운다.
 - workflow 저장소 PR 본문은 `.github/PULL_REQUEST_TEMPLATE.md`를 복사한 임시 파일을 기준으로 채운다.
-- PR의 `6) Verification Contract`는 section block 형식으로 작성한다.
+- PR의 `6) Verification Contract`는 카테고리별 section 아래에 check별 block 형식으로 작성한다.
+- 성공한 검증은 최종 상태와 핵심 evidence만 짧게 적고, 실패, 재시도, 예외만 상세히 남긴다.
 - 생성 직후에는 `gh issue view --json body` 또는 `gh pr view --json body`로 본문이 예상한 줄바꿈과 섹션을 유지하는지 확인한다.
 - Issue template은 최소한 `문제`, `왜 지금`, `범위/비범위`, `write scope`, `context source`, `verification plan`, `open questions`를 포함해야 한다.
 - PR template은 최소한 `연결된 issue`, `범위/비범위`, `write scope`, `verification 결과`, `독립 review 결과`, `feedback follow-up`, `문서 반영`, `리스크`를 포함해야 한다.
@@ -109,7 +110,7 @@
 - 선행조건이 충족되지 않았으면 임의로 우회 구현하지 말고 blocker를 먼저 정리한다.
 - 허용된 write scope 밖의 파일은 수정하지 않는다.
 - source of truth 문서를 함께 업데이트하거나, 업데이트가 불필요한 이유를 남긴다.
-- 검증 명령과 결과를 반드시 남긴다.
+- 검증 명령과 최종 상태를 반드시 남기고, 실패나 예외가 있었다면 요약을 남긴다.
 - 새로 생긴 반복 절차가 있다면 skill 후보로 제안하되, 이번 Issue 범위를 넘는 구현은 하지 않는다.
 - 모호한 선택지가 여러 개면 [docs/product/work-item-catalog.md](../product/work-item-catalog.md)의 기본 결정을 따른다.
 - 실행 중 예상치 못한 dirty change가 있으면 되돌리지 말고 영향 여부만 확인한다.

--- a/docs/operations/workflow-governance.md
+++ b/docs/operations/workflow-governance.md
@@ -68,10 +68,10 @@
 
 - 작업 시작 전 대상 저장소에 `gh issue create`로 이슈를 만든다.
 - 이슈와 PR 본문은 대상 저장소의 Issue/PR template 형식을 따른다.
-- 멀티라인 GitHub 본문은 shell 인라인 `--body`, escaped `\n`, `$'...'` 문자열로 직접 만들지 않는다.
 - GitHub 본문은 먼저 파일로 작성한 뒤 `gh issue create --body-file <path>` 또는 `gh pr create --body-file <path>`로 보낸다.
 - workflow 저장소 Issue 본문은 `.codex/skills/issue-to-exec-plan/templates/github-issue-body.md`를 복사해 채운다.
 - workflow 저장소 PR 본문은 `.github/PULL_REQUEST_TEMPLATE.md`를 복사한 임시 파일을 기준으로 채운다.
+- PR의 `6) Verification Contract`는 section block 형식으로 작성한다.
 - 생성 직후에는 `gh issue view --json body` 또는 `gh pr view --json body`로 본문이 예상한 줄바꿈과 섹션을 유지하는지 확인한다.
 - Issue template은 최소한 `문제`, `왜 지금`, `범위/비범위`, `write scope`, `context source`, `verification plan`, `open questions`를 포함해야 한다.
 - PR template은 최소한 `연결된 issue`, `범위/비범위`, `write scope`, `verification 결과`, `독립 review 결과`, `feedback follow-up`, `문서 반영`, `리스크`를 포함해야 한다.

--- a/docs/references/README.md
+++ b/docs/references/README.md
@@ -4,10 +4,11 @@
 
 현재 참고 문서:
 
-- [docs/plans/git-ranker-harness-issue-pr-roadmap.md](../plans/git-ranker-harness-issue-pr-roadmap.md): 초기 전체 roadmap 원문
+- [git-ranker-harness-issue-pr-roadmap.md](git-ranker-harness-issue-pr-roadmap.md): 초기 전체 roadmap 원문
 - [2026-03-24-readiness-evidence.md](2026-03-24-readiness-evidence.md): `GRW-02` readiness 기준선 판단 근거
 
 원칙:
 
 - 참고 자료는 source of truth가 아니다
 - 현재 작업 지시는 `docs/product/`, `docs/operations/`, `docs/exec-plans/`를 우선한다
+- 역사 roadmap는 현재 계획 문서와 같은 계층에 두지 않는다

--- a/docs/references/git-ranker-harness-issue-pr-roadmap.md
+++ b/docs/references/git-ranker-harness-issue-pr-roadmap.md
@@ -1,6 +1,8 @@
-# Git Ranker Harness Engineering Issue/PR Roadmap
+# Historical: Git Ranker Harness Engineering Issue/PR Roadmap
 
-> 상태: 초기 분해를 남겨두는 역사 문서다. 새 작업은 이 문서보다 아래 문서를 먼저 읽는다.
+> 상태: 초기 분해를 남겨두는 역사 문서다. 현재 계획 source of truth는 이 문서가 아니라 `docs/product/`, `docs/operations/`, `docs/exec-plans/`다.
+>
+> 새 작업은 이 문서보다 아래 문서를 먼저 읽는다.
 >
 > - [AGENTS.md](../../AGENTS.md)
 > - [PLANS.md](../../PLANS.md)


### PR DESCRIPTION
## 1) Summary
- 하네스 시스템 맵과 canonical state machine 문서를 추가하고, planning source of truth와 history 문서 경계를 정리했습니다.
- GitHub issue/PR 본문은 body file로 작성하도록 가드레일을 추가했습니다.
- PR의 `6) Verification Contract`를 check block 형식으로 재구성하고, 성공한 검증은 `Final Status`와 핵심 `Evidence`만 짧게 남기도록 정리했습니다.

## 2) Linked Issue
- Closes #31
- Issue ID: `GRW-11`
- 대상 저장소: `git-ranker-workflow`

## 3) Harness Contract
- Request Type: `architecture/control-plane`
- Context / Source of Truth:
  - `AGENTS.md`
  - `PLANS.md`
  - `docs/operations/workflow-governance.md`
  - `docs/product/harness-roadmap.md`
  - `docs/product/work-item-catalog.md`
  - `docs/architecture/control-plane-map.md`
- Write Scope:
  - `docs/architecture/`
  - `docs/README.md`
  - `docs/operations/`
  - `docs/references/`
  - `docs/exec-plans/`
  - `.codex/skills/issue-to-exec-plan/`
  - `.github/PULL_REQUEST_TEMPLATE.md`
- Branch / Exec Plan:
  - `feat/grw-11-harness-system-map`
  - `docs/exec-plans/completed/2026-04-06-grw-11-harness-system-map.md`

## 4) Scope
- In Scope:
  - 하네스 시스템 맵과 상태 전이 정의
  - 역사 roadmap 이관과 인덱스 정리
  - GitHub issue/PR body-file 가드레일 추가
  - PR Verification Contract reporting format 정리
- Out of Scope:
  - request routing 세부 정책 정의
  - context pack registry 상세 작성
  - verification contract registry 수치 확정
  - backend/frontend 앱 코드 변경

## 5) Outputs
- 변경된 문서 / 파일 / 디렉터리:
  - `docs/architecture/harness-system-map.md`
  - `docs/architecture/control-plane-map.md`
  - `docs/README.md`
  - `docs/references/README.md`
  - `docs/references/git-ranker-harness-issue-pr-roadmap.md`
  - `docs/operations/workflow-governance.md`
  - `.codex/skills/issue-to-exec-plan/SKILL.md`
  - `.codex/skills/issue-to-exec-plan/templates/github-issue-body.md`
  - `.github/PULL_REQUEST_TEMPLATE.md`
  - `docs/exec-plans/completed/2026-04-06-grw-11-harness-system-map.md`
- 후속 작업이 바로 참조할 산출물:
  - architecture source of truth for `GRW-12`~`GRW-17`
  - GitHub body-file guardrail
  - itemized PR verification template with concise pass reporting

## 6) Verification Contract

### Docs / Policy

#### Check Item
- Name: PR template verification structure
- Command / Check: `nl -ba .github/PULL_REQUEST_TEMPLATE.md | sed -n '24,93p'`
- Final Status: `PASS`
- Evidence: `Verification Contract`가 category section 아래 `#### Check Item` block, `Final Status`, `Evidence`, `Failure / Exception` 필드로 재구성됐습니다.
- Failure / Exception: 없음

#### Check Item
- Name: Workflow governance alignment
- Command / Check: `nl -ba docs/operations/workflow-governance.md | sed -n '29,113p'`
- Final Status: `PASS`
- Evidence: PR 필수 항목, evidence 규칙, verification 기록 규칙이 `최종 상태 + 핵심 evidence + 실패/예외 요약` 기준으로 정렬됐습니다.
- Failure / Exception: 없음

#### Check Item
- Name: Harness system map verification report definition
- Command / Check: `nl -ba docs/architecture/harness-system-map.md | sed -n '36,43p'`
- Final Status: `PASS`
- Evidence: canonical artifact의 `Verification report` 정의가 `실행 명령, 최종 상태, 핵심 evidence, 실패/예외 요약`으로 갱신됐습니다.
- Failure / Exception: 없음

### Type / Lint / Test / Build

#### Check Item
- Name: 문서 patch integrity
- Command / Check: `git diff --check HEAD^ HEAD`
- Final Status: `PASS`
- Evidence: whitespace 또는 patch formatting 문제 없음
- Failure / Exception: 없음

### Manual Check

#### Check Item
- Name: Verification section readability review
- Command / Check: Markdown section structure review
- Final Status: `PASS`
- Evidence: category별 section 아래 check block으로 구분돼, flat한 `Command / Check`, `Result` 나열보다 항목 경계가 명확해졌습니다.
- Failure / Exception: 없음

### Other Task-Specific Contract

#### Check Item
- Name: 문서 전용 변경
- Command / Check: N/A
- Final Status: `N/A`
- Evidence: 런타임 코드, 테스트, 빌드 파이프라인 변경 없음
- Failure / Exception: 없음

## 7) Independent Review
- Implementer: Codex
- Reviewer: Pending
- Reviewer Input: PR diff, `docs/exec-plans/completed/2026-04-06-grw-11-harness-system-map.md`, verification 결과
- Review Verdict: Pending
- Findings / Change Requests: Pending

## 8) Source of Truth Update
- 업데이트한 문서:
  - `docs/architecture/harness-system-map.md`
  - `docs/architecture/control-plane-map.md`
  - `docs/README.md`
  - `docs/operations/workflow-governance.md`
  - `.github/PULL_REQUEST_TEMPLATE.md`
  - `docs/references/README.md`
  - `docs/references/git-ranker-harness-issue-pr-roadmap.md`
  - `.codex/skills/issue-to-exec-plan/SKILL.md`
  - `.codex/skills/issue-to-exec-plan/templates/github-issue-body.md`
- 업데이트하지 않은 문서와 사유:
  - `docs/product/*`: roadmap/catalog의 작업 순서는 그대로 유지되어 추가 변경이 필요하지 않았습니다.

## 9) Feedback / Guardrail Follow-up
- 이번 작업에서 실제로 발생한 실패 / 예외 / 취약 지점:
  - 기존 PR verification section은 `Command / Check`, `Result`가 flat하게 이어져 개별 검증 항목 경계와 최종 상태를 빠르게 읽기 어려웠습니다.
- 새 guardrail 후보:
  - PR의 `6) Verification Contract`는 category section 아래 check block 형식으로 작성합니다.
  - 성공한 검증은 `Final Status`와 핵심 `Evidence`만 기록하고, 실패, 재시도, 예외만 상세히 남깁니다.
  - 항목이 여러 개면 같은 `#### Check Item` block을 복제해 개별 검증 단위를 분리합니다.
- 후속 Issue 또는 TODO:
  - 없음

## 10) Risks and Rollback
- Risks:
  - 문서/skill/template 변경이므로 런타임 영향은 없습니다.
  - downstream PR 작성자가 새 verification block 형식에 익숙해질 때까지 작성 편차가 있을 수 있습니다.
- Rollback Plan:
  - 커밋 `3ede70931dfa87bdc98fc64398b523cb993624cf` revert
  - 커밋 `059de69c98c2a6893d9e2c57326da8b8af9f4328` revert
  - 커밋 `78c201be7847f5591c38a5530acb5afa3c6d919d` revert

## 11) Checklist
- [x] 연결된 Issue가 있다
- [x] Scope / Out of Scope가 적혀 있다
- [x] Write Scope가 적혀 있다
- [x] Verification 최종 상태와 예외가 기입되어 있다
- [ ] Implementer와 Reviewer가 분리되어 있다
- [x] Source of Truth 반영 여부가 적혀 있다
- [x] Feedback 또는 후속 guardrail 후보가 적혀 있다
