### PR TITLE
[Task] GRW-12 요청 라우팅 정책과 stable 문서 task ID 규칙 정리

### DIFF
--- a/.codex/skills/issue-to-exec-plan/SKILL.md
+++ b/.codex/skills/issue-to-exec-plan/SKILL.md
@@ -61,6 +61,7 @@ workflow 저장소에서 멀티라인 Issue 본문을 만들 때는 `.codex/skil
 - 예정된 verification 명령
 - 남아 있는 질문이나 blocker
 - 관련 GitHub Issue와 branch/slug
+- stable source of truth 문서에 임시 work item ID를 남겨야 하는지 여부와, 남긴다면 close-out 전에 제거하거나 planning/history 문서로 이동할 계획
 
 ## Forbidden Shortcuts
 
@@ -69,6 +70,7 @@ workflow 저장소에서 멀티라인 Issue 본문을 만들 때는 `.codex/skil
 - verification을 `문서 확인`, `테스트 실행`처럼 추상적으로 쓰지 않는다.
 - 선행조건이 불명확한데 `Ready` 또는 `In Progress`로 올리지 않는다.
 - 애매한 요구사항을 임의 해석해 plan 본문에 박지 않는다.
+- `docs/architecture/`, `docs/operations/`, `docs/domain/`, `docs/reliability/`, `docs/security/` 같은 stable source of truth 문서에 현재/후속 work item ID를 설명용 문장으로 남기지 않는다.
 - 멀티라인 GitHub Issue 본문을 `gh issue create --body '...'` 또는 escaped `\n` 문자열로 직접 보내지 않는다.
 - Issue 생성 후 `gh issue view --json body` 확인 없이 줄바꿈이 정상이라고 가정하지 않는다.
 

--- a/.codex/skills/issue-to-exec-plan/SKILL.md
+++ b/.codex/skills/issue-to-exec-plan/SKILL.md
@@ -70,7 +70,7 @@ workflow 저장소에서 멀티라인 Issue 본문을 만들 때는 `.codex/skil
 - verification을 `문서 확인`, `테스트 실행`처럼 추상적으로 쓰지 않는다.
 - 선행조건이 불명확한데 `Ready` 또는 `In Progress`로 올리지 않는다.
 - 애매한 요구사항을 임의 해석해 plan 본문에 박지 않는다.
-- `docs/architecture/`, `docs/operations/`, `docs/domain/`, `docs/reliability/`, `docs/security/` 같은 stable source of truth 문서에 현재/후속 work item ID를 설명용 문장으로 남기지 않는다.
+- `docs/architecture/`, `docs/operations/`, `docs/domain/`, `docs/reliability/`, `docs/security/`, `docs/quality-score/` 같은 stable source of truth 문서에 현재/후속 work item ID를 설명용 문장으로 남기지 않는다.
 - 멀티라인 GitHub Issue 본문을 `gh issue create --body '...'` 또는 escaped `\n` 문자열로 직접 보내지 않는다.
 - Issue 생성 후 `gh issue view --json body` 확인 없이 줄바꿈이 정상이라고 가정하지 않는다.
 

--- a/docs/architecture/harness-system-map.md
+++ b/docs/architecture/harness-system-map.md
@@ -97,7 +97,7 @@
 - `Rejected`: 대화성 요청, 범위 밖 요청, 사용자 취소처럼 작업 자체를 진행하지 않는 경우다.
 - `Blocked`: 선행조건 부족, 외부 의존성, 권한 문제, canonical source 부재로 현재 이슈 안에서 더 진행할 수 없는 경우다.
 - `Completed`: verification 통과, reviewer 승인, feedback close-out이 모두 끝난 경우다.
-- `Repairing`은 terminal state가 아니다. 반복 실패가 누적되면 `GRW-15`, `GRW-17`에서 정의할 retry budget과 guardrail 정책에 따라 `Blocked` 또는 후속 Issue로 넘긴다.
+- `Repairing`은 terminal state가 아니다. 반복 실패가 누적되면 verification contract registry와 feedback/guardrail policy에 정의된 retry budget 기준에 따라 `Blocked` 또는 후속 planning으로 넘긴다.
 
 ## Role Separation Invariants
 
@@ -115,11 +115,11 @@
 - `Completed` 판정은 PR의 verification 결과와 reviewer verdict, exec plan의 close-out이 함께 있어야 성립한다.
 - 완료된 exec plan은 `docs/exec-plans/completed/`로 옮기고, 후속 Issue가 이 문서를 전제조건으로 참조한다.
 
-## Follow-up Ownership
+## Detailed Policy Surfaces
 
-- `GRW-12`는 `Router`, `Interviewing`, `Rejected` semantics를 세분화한다.
-- `GRW-13`은 `Planned`에서 `Context Ready`로 가는 규칙을 registry로 고정한다.
-- `GRW-14`는 `Context Ready`와 `Implementing` 단계의 tool boundary를 상세화한다.
-- `GRW-15`는 `Verifying`, `Repairing`, `Blocked` semantics와 retry budget을 명시한다.
-- `GRW-16`은 `Reviewing` 단계의 reviewer input과 verdict 규칙을 구체화한다.
-- `GRW-17`은 `Feedback Pending`과 guardrail 승격 규칙을 ledger 형태로 정의한다.
+- request routing and ambiguity interview policy는 `Router`, `Interviewing`, `Rejected` semantics를 세분화한다.
+- context pack registry는 `Planned`에서 `Context Ready`로 가는 규칙을 registry 형태로 고정한다.
+- tool boundary matrix는 `Context Ready`와 `Implementing` 단계의 허용 도구와 write scope 경계를 상세화한다.
+- verification contract registry는 `Verifying`, `Repairing`, `Blocked` semantics와 retry budget을 명시한다.
+- review policy는 `Reviewing` 단계의 reviewer input과 verdict 규칙을 구체화한다.
+- feedback ledger/policy는 `Feedback Pending`과 guardrail 승격 규칙을 고정한다.

--- a/docs/exec-plans/completed/2026-04-06-grw-12-request-routing-ambiguity-policy.md
+++ b/docs/exec-plans/completed/2026-04-06-grw-12-request-routing-ambiguity-policy.md
@@ -1,0 +1,120 @@
+# 2026-04-06-grw-12-request-routing-ambiguity-policy
+
+- Issue ID: `GRW-12`
+- GitHub Issue: `#33`
+- Status: `Completed`
+- Repository: `git-ranker-workflow`
+- Branch Name: `feat/grw-12-request-routing-ambiguity-policy`
+- Task Slug: `2026-04-06-grw-12-request-routing-ambiguity-policy`
+
+## Problem
+
+`GRW-11`은 `Router`, `Interviewing`, `Rejected` 상태의 상위 semantics를 정의했지만, 실제 intake 단계에서 어떤 요청을 `대화`, `모호한 요청`, `즉시 실행 가능한 작업`으로 분류할지와 인터뷰를 언제 시작하고 끝낼지는 아직 문서화되지 않았다.
+
+이 상태로 후속 context pack, tool boundary, verification, review, intake skill 작업을 진행하면 같은 요청이 작업자별로 다른 route를 타고, exec plan 생성 여부와 질문 개수도 일관되지 않게 된다.
+
+## Why Now
+
+요청 라우팅 정책은 context pack, tool boundary, verification, review policy가 공유해야 하는 intake 기준이다. `GRW-12`가 먼저 고정돼야 다음 단계가 "무엇을 실행 가능한 작업으로 볼 것인가"를 같은 기준으로 다룰 수 있다.
+
+또한 pilot과 intake skill이 재현 가능한 intake 절차를 사용하려면, 인터뷰가 요구사항을 늘리는 절차가 아니라 범위를 줄여 exec plan 가능한 작업으로 만드는 절차라는 점을 먼저 source of truth에 고정해야 한다.
+
+## Scope
+
+- `docs/operations/` 아래에 request routing과 ambiguity interview 정책 문서를 작성한다.
+- 요청 분류 기준, ambiguity signal, 인터뷰 질문 규칙, 종료 조건, 일반 대화 fallback, `Rejected` semantics를 정의한다.
+- operations 인덱스와 governance 문서가 새 정책을 참조하도록 갱신한다.
+- stable source of truth 문서에 남아 있는 직접적인 work item ID 참조를 일반 서술로 정리한다.
+- 이후 close-out에서 같은 문제가 반복되지 않도록 governance와 exec plan 작성 절차에 task ID 정리 규칙을 추가한다.
+- `GRW-12` exec plan을 작성하고 완료 시점에 close-out을 남긴다.
+
+## Non-scope
+
+- 신규 에이전트 런타임 구현
+- backend/frontend 앱 코드 변경
+- intake/ambiguity skill 작성
+- context pack registry, tool boundary, verification contract, review policy의 상세 정의
+
+## Write Scope
+
+- `.codex/skills/issue-to-exec-plan/`
+- `docs/architecture/`
+- `docs/operations/`
+- `docs/quality-score/`
+- `docs/exec-plans/`
+
+## Outputs
+
+- request routing과 ambiguity interview를 함께 다루는 운영 정책 문서
+- 갱신된 `docs/operations/README.md`
+- 갱신된 `docs/operations/workflow-governance.md`
+- stable source of truth용 task ID cleanup 규칙
+- evergreen harness 문서의 task ID 일반화
+- `GRW-12` 실행 기록
+
+## Working Decisions
+
+- route category는 `대화`, `모호한 요청`, `즉시 실행 가능한 작업` 세 가지로 유지한다.
+- ambiguity interview는 새 기능 아이디어를 늘리는 절차가 아니라 범위, 저장소, write scope, 완료 조건을 줄여 고정하는 절차로 정의한다.
+- 일반 대화는 exec plan을 만들지 않고 응답으로 종료한다.
+- `Rejected`는 대화성 요청, 사용자 취소, 범위 밖 요청, canonical source 부재처럼 실행을 계속하지 않기로 결정한 경우에만 사용한다.
+
+## Verification
+
+- `sed -n '1,320p' docs/operations/request-routing-policy.md`
+  - 결과: route category 3종, ambiguity signal, immediate execution criteria, interview rules, exit condition, `Rejected` reason, example classification 5건이 한 문서에 정리된 것을 확인했다.
+- `rg -n "대화|모호한 요청|즉시 실행 가능한 작업|ambiguity|interview|Rejected|fallback" docs/operations/request-routing-policy.md docs/operations/workflow-governance.md docs/operations/README.md`
+  - 결과: 새 정책 문서, governance, operations 인덱스에서 intake 핵심 용어와 `Rejected` semantics가 함께 grep되는 것을 확인했다.
+- `sed -n '1,180p' docs/operations/workflow-governance.md`
+  - 결과: 요청 intake 규칙 section과 stable source of truth의 task ID cleanup 규칙이 추가됐고, `즉시 실행 가능한 작업`만 issue와 exec plan으로 보낸다는 규칙이 GitHub Issue/PR 운영 규칙과 실행 순서에 반영된 것을 확인했다.
+- `sed -n '1,80p' docs/operations/README.md`
+  - 결과: operations 인덱스가 `request-routing-policy.md`를 현재 기준 문서로 가리키는 것을 확인했다.
+- `rg -n "GRW-[0-9]+|GRW-S[0-9]+|GRB-[0-9]+|GRC-[0-9]+" docs/architecture docs/operations docs/domain docs/reliability docs/security docs/quality-score`
+  - 결과: stable source of truth 쪽에서는 식별자 형식 설명과 historical baseline 문맥만 남고, evergreen harness 설명 문장에서는 직접적인 work item ID가 제거된 것을 확인했다.
+- `sed -n '96,132p' docs/architecture/harness-system-map.md`
+  - 결과: 후속 정책 surface와 retry/guardrail 설명이 work item ID 대신 자산 이름 기준으로 일반화된 것을 확인했다.
+- `sed -n '1,120p' .codex/skills/issue-to-exec-plan/SKILL.md`
+  - 결과: exec plan 작성 skill에 stable source of truth 문서의 task ID cleanup 계획과 금지 규칙이 반영된 것을 확인했다.
+- GitHub Issue `#33` body 확인
+  - 결과: issue 본문이 template 섹션과 줄바꿈을 유지한 채 생성된 것을 확인했다.
+- 예시 요청 5건 수동 검토
+  - 결과: `대화`, `모호한 요청`, `즉시 실행 가능한 작업`, `Rejected` close-out이 서로 다른 다음 행동을 갖도록 일관되게 정리된 것을 확인했다.
+
+## Evidence
+
+문서 작업이므로 브라우저, 로그, 메트릭 artifact는 만들지 않는다. 대신 아래를 근거로 남긴다.
+
+- `docs/operations/request-routing-policy.md`의 route taxonomy와 ambiguity interview 규칙
+- `docs/operations/workflow-governance.md`의 intake gate와 갱신된 실행 순서
+- `docs/operations/README.md`의 source of truth 인덱스 반영
+- `docs/architecture/harness-system-map.md`, `docs/operations/workflow-verification-runtime.md`, `docs/operations/observability-reference.md`, `docs/operations/frontend-runtime-reference.md`, `docs/quality-score/agent-readiness-scorecard.md`의 task ID 일반화 결과
+- `.codex/skills/issue-to-exec-plan/SKILL.md`의 stable 문서 cleanup 가드레일
+- GitHub Issue `#33` 본문 확인 결과
+
+## Risks or Blockers
+
+- 이후 skill이나 후속 정책 문서를 작성할 때 stable source of truth 대신 planning 문서의 task ID를 다시 본문으로 끌어오면 같은 drift가 반복될 수 있다.
+- `missing-canonical-source`와 `non-executable-after-interview`는 둘 다 non-execution close-out이지만, 이후 planning workflow에서 후속 issue 생성 규칙을 더 세밀하게 다룰 여지가 있다.
+
+## Next Preconditions
+
+- `GRW-13`: context pack registry와 task-to-context 매핑 정의
+- `GRW-14`: tool boundary matrix와 write scope 거버넌스 정의
+- `GRW-S06`: intake/ambiguity skill pack
+
+## Docs Updated
+
+- `.codex/skills/issue-to-exec-plan/SKILL.md`
+- `docs/architecture/harness-system-map.md`
+- `docs/operations/request-routing-policy.md`
+- `docs/operations/workflow-governance.md`
+- `docs/operations/README.md`
+- `docs/operations/workflow-verification-runtime.md`
+- `docs/operations/observability-reference.md`
+- `docs/operations/frontend-runtime-reference.md`
+- `docs/quality-score/agent-readiness-scorecard.md`
+- `docs/exec-plans/completed/2026-04-06-grw-12-request-routing-ambiguity-policy.md`
+
+## Skill Consideration
+
+이번 작업은 skill을 직접 작성하는 범위는 아니다. 대신 후속 intake/ambiguity skill이 그대로 재사용할 수 있게 route 결정 입력, ambiguity signal, interview 종료 조건, `Rejected` close-out reason을 문서형 source of truth로 먼저 고정했다.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -5,6 +5,7 @@
 현재 기준 문서:
 
 - [workflow-governance.md](workflow-governance.md)
+- [request-routing-policy.md](request-routing-policy.md)
 - [workflow-verification-runtime.md](workflow-verification-runtime.md)
 - [manual-refresh-flow.md](manual-refresh-flow.md)
 - [daily-batch-flow.md](daily-batch-flow.md)

--- a/docs/operations/frontend-runtime-reference.md
+++ b/docs/operations/frontend-runtime-reference.md
@@ -69,5 +69,5 @@
 
 ## Harness Notes
 
-- `GRC-03` 이후 frontend build는 local font와 필수 `NEXT_PUBLIC_*` env를 전제로 반복 실행 가능해야 한다.
+- frontend build는 local font와 필수 `NEXT_PUBLIC_*` env를 전제로 반복 실행 가능해야 한다.
 - ranking harness는 backend API, GitHub avatar CDN, proxy locale redirect를 함께 고려해야 한다.

--- a/docs/operations/observability-reference.md
+++ b/docs/operations/observability-reference.md
@@ -1,6 +1,6 @@
 # Observability Reference
 
-이 문서는 `GRW-03` 범위에서 후속 harness가 바로 참조할 수 있는 로그 이벤트, 공통 필드, 메트릭 이름, 관측 endpoint를 정리한다.
+이 문서는 후속 harness가 바로 참조할 수 있는 로그 이벤트, 공통 필드, 메트릭 이름, 관측 endpoint를 정리한다.
 
 ## 로그 공통 규칙
 

--- a/docs/operations/request-routing-policy.md
+++ b/docs/operations/request-routing-policy.md
@@ -1,0 +1,114 @@
+# Request Routing Policy
+
+이 문서는 [../architecture/harness-system-map.md](../architecture/harness-system-map.md)의 `Router`, `Interviewing`, `Rejected` 상태를 실제 intake 운영 규칙으로 구체화한다. 목표는 사용자 요청을 `대화`, `모호한 요청`, `즉시 실행 가능한 작업`으로 일관되게 분류하고, ambiguity interview가 요구사항을 늘리지 않고 실행 범위를 줄이도록 고정하는 것이다.
+
+## Routing Decision Order
+
+1. 먼저 요청이 작업 실행을 요구하는지, 아니면 응답만으로 끝나는 `대화`인지 판단한다.
+2. 작업 실행 의도가 있으면 ambiguity signal이 남아 있는지 확인한다.
+3. ambiguity signal이 없고 단일 목표와 write scope와 verification을 고정할 수 있으면 `즉시 실행 가능한 작업`으로 분류한다.
+4. ambiguity signal이 남아 있으면 `모호한 요청`으로 분류하고 interview를 시작한다.
+5. `대화`, 사용자 취소, 범위 밖 요청, canonical source 부재처럼 실행을 계속하지 않기로 결정한 경우는 terminal close-out을 `Rejected`로 기록한다.
+
+## Route Categories
+
+| Route | 선택 기준 | 즉시 해야 할 일 | 상태 전이 |
+| --- | --- | --- | --- |
+| `대화` | 설명, 요약, 번역, 브레인스토밍, 코드 리뷰 의견처럼 응답만으로 끝나는 요청이거나, 사용자가 명시적으로 수정하지 말라고 했다. | 답변만 제공하고 issue, exec plan, 파일 편집을 시작하지 않는다. | `Received -> Routed -> Rejected` (`conversation-only`) |
+| `모호한 요청` | 작업 실행 의도는 있지만 최소 하나 이상의 ambiguity signal이 남아 있다. | source of truth를 먼저 확인하고, 남는 blocker만 interview 질문으로 줄인다. issue와 exec plan은 아직 만들지 않는다. | `Received -> Routed -> Interviewing` |
+| `즉시 실행 가능한 작업` | 단일 목표, 대상 저장소, 예상 산출물, write scope, verification을 현재 문서와 코드에서 고정할 수 있다. | GitHub issue와 active exec plan을 만들고 작업을 시작한다. | `Received -> Routed -> Planned` |
+
+`Rejected`는 네 번째 route가 아니라 terminal non-execution close-out이다. `대화`, 사용자 취소, 범위 밖 요청, interview 실패가 모두 `Rejected`로 닫힐 수 있다.
+
+## Ambiguity Signals
+
+아래 중 하나라도 남아 있으면 `모호한 요청`으로 분류한다.
+
+- 대상 저장소, 파일, 문서 위치가 둘 이상으로 해석되며 source of truth만으로 하나로 줄일 수 없다.
+- 하나의 요청 안에 둘 이상의 목표가 섞여 있어 `Issue 1개 = PR 1개` 원칙을 바로 적용할 수 없다.
+- 완료 조건이나 산출물 형태가 없다. 예: "좀 개선", "정리", "다 고쳐줘", "알아서 처리".
+- write scope가 잠기지 않는다. 예: workflow 문서 변경인지, backend 코드 수정인지, client UI 수정인지가 갈린다.
+- 검증 기준을 적을 수 없다. 어떤 명령이나 어떤 문서 검토로 완료를 판정할지 정할 수 없다.
+- source of truth가 서로 충돌하거나, 현재 canonical source가 없어서 작업자가 임의 정책을 만들어야 한다.
+- 제품/디자인/운영 선호를 새로 결정해야 한다. source of truth에 없는 선택을 작업자가 대신 정하면 scope가 커진다.
+
+아래는 ambiguity signal로 보지 않는다.
+
+- 저장소 안에서 확인 가능한 사실을 아직 읽지 않은 상태
+- `docs/product/work-item-catalog.md`나 기존 exec plan이 이미 기본 결정을 제공하는 경우
+- 실행 도중 필요한 tool approval이나 네트워크 권한 요청만 남아 있는 경우
+
+## Immediate Execution Criteria
+
+아래 항목을 모두 만족하면 `즉시 실행 가능한 작업`으로 본다.
+
+1. 목표가 하나다.
+2. 대상 저장소가 하나로 고정된다.
+3. 바꿀 자산 종류가 드러난다. 예: `docs/operations/`, 특정 app 모듈, 특정 test.
+4. 산출물과 비범위를 exec plan에 바로 적을 수 있다.
+5. 검증 명령 또는 문서 검토 절차를 적을 수 있다.
+6. source of truth만으로 남은 선택을 처리할 수 있고, 새 사용자 선호를 물을 필요가 없다.
+
+위 기준을 만족하면 issue와 active exec plan을 먼저 만들고, 그 다음 구현이나 문서 편집을 시작한다.
+
+## Ambiguity Interview Policy
+
+### Interview Objectives
+
+interview의 목적은 요청을 더 크게 정의하는 것이 아니라, 아래 다섯 항목을 잠그는 것이다.
+
+- 문제 정의
+- 범위와 비범위
+- 대상 저장소와 write scope
+- 기대 산출물
+- verification 방법
+
+### Interview Rules
+
+- 질문 전에 source of truth와 저장소를 먼저 읽어, 사용자에게 묻지 않아도 되는 사실은 직접 해소한다.
+- 질문은 기본적으로 한 번에 하나의 blocker만 겨냥한다.
+- 같은 답으로 함께 닫히는 ambiguity가 명확할 때만 한 라운드에 최대 세 가지까지 묶어 묻는다.
+- 질문은 구현 아이디어를 늘리지 말고 범위를 줄이는 방향이어야 한다.
+- 여러 목표가 섞여 있으면 "무엇을 먼저 한 issue로 고정할지"를 묻는다.
+- 여러 저장소가 섞여 있으면 cross-repo 대작업으로 진행하지 말고, 이번 턴의 primary repo를 먼저 고정한다.
+- work item catalog나 governance에 기본 결정이 있으면 그 결정을 기본값으로 사용하고, 사용자에게는 예외가 필요한 경우만 묻는다.
+- ambiguity가 해소되면 바로 issue와 exec plan 형식으로 요약해 범위를 고정한다.
+
+### Interview Exit Conditions
+
+| 종료 상태 | 기준 | 다음 행동 |
+| --- | --- | --- |
+| `Planned` | issue 본문과 exec plan의 `Problem`, `Why Now`, `Scope`, `Non-scope`, `Write Scope`, `Verification`을 채울 수 있다. | GitHub issue를 만들고 active exec plan을 작성한다. |
+| `Blocked` | 실행 의도는 유지되지만, 사용자 응답이나 외부 canonical source가 없어 더 줄일 수 없다. | blocker를 명시하고 작업을 멈춘다. |
+| `Rejected` | 사용자가 취소했거나, 대화만 원하거나, 허용된 저장소 밖 요청이거나, 필요한 narrowing이 source of truth 없이 새 정책 발명에 가까워졌다. | 실행을 종료하고 이유를 남긴다. |
+
+같은 ambiguity signal이 두 번의 interview 라운드 뒤에도 그대로 남아 있으면 더 많은 질문으로 밀어붙이지 않는다. 이 경우 `Blocked` 또는 `Rejected`로 정리한다.
+
+## Rejected Semantics
+
+`Rejected`는 실패가 아니라 "이번 턴에서 실행을 계속하지 않음"을 뜻한다. 아래 reason을 canonical close-out reason으로 사용한다.
+
+| Reason | 의미 | 예시 처리 |
+| --- | --- | --- |
+| `conversation-only` | 응답형 요청으로 끝났다. | 답변만 제공하고 종료 |
+| `cancelled` | 사용자가 진행을 취소했다. | 편집 중지 후 종료 |
+| `out-of-scope` | 허용 저장소나 현재 작업 경계를 벗어난다. | 범위 밖임을 알리고 종료 |
+| `missing-canonical-source` | 작업자가 새 canonical policy를 발명해야만 진행 가능하다. | 후속 planning issue 후보로 남기고 종료 |
+| `non-executable-after-interview` | 인터뷰 후에도 한 issue로 고정할 수 없다. | split 또는 후속 issue 제안 후 종료 |
+
+## Example Classification
+
+| 요청 | 판정 | 이유 | 다음 행동 |
+| --- | --- | --- | --- |
+| "`docs/README.md` 구조를 설명해줘" | `대화` | 응답만으로 끝나는 설명 요청이다. | 답변만 제공하고 종료 |
+| "현재 catalog에 있는 request routing policy 작업을 진행해줘" | `즉시 실행 가능한 작업` | work item catalog와 시스템 문서가 이미 범위와 write scope를 제공해 issue와 exec plan을 바로 만들 수 있다. | issue 생성 후 exec plan 작성 |
+| "랭킹 화면 좀 개선해줘" | `모호한 요청` | 대상 저장소, 화면 범위, 완료 조건이 없다. | 어떤 화면과 어떤 변경을 원하는지 interview |
+| "backend랑 client 인증 흐름 다 정리하고 필요한 것들 한 번에 고쳐줘" | `모호한 요청` | 여러 저장소와 여러 목표가 섞여 있어 한 issue로 고정할 수 없다. | 이번 턴의 primary repo와 첫 issue를 고르도록 interview |
+| "이 작업은 취소하고 지금은 정책 방향만 얘기하자" | `Rejected` (`cancelled`) | 실행 요청이 철회됐고 대화로 전환됐다. | 편집하지 않고 대화만 이어감 |
+
+## Governance Hooks
+
+- `즉시 실행 가능한 작업`만 GitHub issue와 active exec plan을 만든다.
+- `모호한 요청` 단계에서는 issue, exec plan, 파일 편집을 시작하지 않는다.
+- `대화`와 `Rejected` close-out은 문서 변경 없이 응답 또는 종료로 닫는다.
+- 후속 intake/ambiguity skill은 이 문서의 route taxonomy와 interview exit condition을 그대로 재사용한다.

--- a/docs/operations/workflow-governance.md
+++ b/docs/operations/workflow-governance.md
@@ -11,7 +11,7 @@
 ## stable source of truth의 task ID 규칙
 
 - `docs/product/`, `docs/exec-plans/`, GitHub Issue/PR 본문, baseline이나 historical snapshot처럼 tracking이 본질인 문서는 work item ID를 직접 써도 된다.
-- `docs/architecture/`, `docs/operations/`, `docs/domain/`, `docs/reliability/`, `docs/security/` 같은 stable source of truth 문서에는 future work나 follow-up 설명을 위해 직접적인 work item ID를 남기지 않는다.
+- `docs/architecture/`, `docs/operations/`, `docs/domain/`, `docs/reliability/`, `docs/security/`, `docs/quality-score/` 같은 stable source of truth 문서에는 future work나 follow-up 설명을 위해 직접적인 work item ID를 남기지 않는다.
 - stable 문서에서 후속 확장을 가리킬 때는 task ID 대신 정책, registry, skill pack, guardrail 같은 자산 이름을 쓴다.
 - task 완료 시 stable 문서에 임시로 넣었던 work item ID는 제거하거나 서술형 이름으로 치환한다.
 - Issue ID 형식, 브랜치명 규칙처럼 식별자 형식 자체를 설명하는 문맥은 예외다.

--- a/docs/operations/workflow-governance.md
+++ b/docs/operations/workflow-governance.md
@@ -8,12 +8,27 @@
 - 다른 디렉터리 문서를 가리킬 때도 현재 문서 위치를 기준으로 상대경로를 적는다.
 - 로컬 도구나 응답 메시지에서만 절대경로를 사용하고, 저장소 문서 본문에는 넣지 않는다.
 
+## stable source of truth의 task ID 규칙
+
+- `docs/product/`, `docs/exec-plans/`, GitHub Issue/PR 본문, baseline이나 historical snapshot처럼 tracking이 본질인 문서는 work item ID를 직접 써도 된다.
+- `docs/architecture/`, `docs/operations/`, `docs/domain/`, `docs/reliability/`, `docs/security/` 같은 stable source of truth 문서에는 future work나 follow-up 설명을 위해 직접적인 work item ID를 남기지 않는다.
+- stable 문서에서 후속 확장을 가리킬 때는 task ID 대신 정책, registry, skill pack, guardrail 같은 자산 이름을 쓴다.
+- task 완료 시 stable 문서에 임시로 넣었던 work item ID는 제거하거나 서술형 이름으로 치환한다.
+- Issue ID 형식, 브랜치명 규칙처럼 식별자 형식 자체를 설명하는 문맥은 예외다.
+
 ## Issue/PR 단위 규칙
 
 - 원칙적으로 `Issue 1개 = PR 1개`
 - 하나의 PR은 하나의 목표만 해결한다
 - 한 PR에서 여러 저장소를 동시에 건드리는 경우는 피한다
 - cross-repo 작업은 `workflow 문서 PR`과 `앱 코드 PR`로 나눈다
+
+## 요청 intake 규칙
+
+- 작업 시작 전 [request-routing-policy.md](request-routing-policy.md)로 요청을 `대화`, `모호한 요청`, `즉시 실행 가능한 작업`으로 분류한다.
+- `즉시 실행 가능한 작업`만 GitHub issue와 exec plan을 만든다.
+- `모호한 요청`은 source of truth로 줄일 수 있는 ambiguity를 먼저 제거하고, 남는 blocker만 interview 질문으로 다룬다.
+- `대화` 또는 `Rejected` close-out인 요청은 파일 편집을 시작하지 않는다.
 
 ## 각 Issue에 반드시 들어가야 할 내용
 
@@ -66,7 +81,7 @@
 
 ## GitHub Issue/PR 운영 규칙
 
-- 작업 시작 전 대상 저장소에 `gh issue create`로 이슈를 만든다.
+- `즉시 실행 가능한 작업`으로 판정된 뒤 대상 저장소에 `gh issue create`로 이슈를 만든다.
 - 이슈와 PR 본문은 대상 저장소의 Issue/PR template 형식을 따른다.
 - GitHub 본문은 먼저 파일로 작성한 뒤 `gh issue create --body-file <path>` 또는 `gh pr create --body-file <path>`로 보낸다.
 - workflow 저장소 Issue 본문은 `.codex/skills/issue-to-exec-plan/templates/github-issue-body.md`를 복사해 채운다.
@@ -84,12 +99,13 @@
 
 현재 기준 실행 순서:
 
-1. 대상 저장소의 `develop` 최신 상태를 기준으로 worktree 또는 branch를 만든다.
-2. body file을 준비한 뒤 `gh issue create --body-file ...`로 대상 저장소 이슈를 만든다.
-3. 이슈 번호를 브랜치명과 exec plan에 연결한다.
-4. 작업 후 PR body file을 준비하고 `gh pr create --base develop --body-file ...`로 PR을 연다.
-5. 생성 직후 `gh issue view --json body` 또는 `gh pr view --json body`로 본문 렌더링을 확인한다.
-6. PR 본문에 검증 결과, 독립 review 결과, 문서 반영 여부, 남은 리스크를 채운다.
+1. [request-routing-policy.md](request-routing-policy.md)로 요청을 분류하고, `즉시 실행 가능한 작업`만 다음 단계로 보낸다.
+2. 대상 저장소의 `develop` 최신 상태를 기준으로 worktree 또는 branch를 만든다.
+3. body file을 준비한 뒤 `gh issue create --body-file ...`로 대상 저장소 이슈를 만든다.
+4. 이슈 번호를 브랜치명과 exec plan에 연결한다.
+5. 작업 후 PR body file을 준비하고 `gh pr create --base develop --body-file ...`로 PR을 연다.
+6. 생성 직후 `gh issue view --json body` 또는 `gh pr view --json body`로 본문 렌더링을 확인한다.
+7. PR 본문에 검증 결과, 독립 review 결과, 문서 반영 여부, 남은 리스크를 채운다.
 
 ## 문서, SKILL, exec plan의 역할
 
@@ -141,6 +157,7 @@
 - 검증 명령이 PR이나 exec plan에 남아 있다
 - 후속 작업의 전제조건이 명확하다
 - source of truth 문서가 함께 업데이트되었거나, 업데이트 불필요 사유가 명시되어 있다
+- stable source of truth 문서에 남긴 임시 work item ID가 있다면 close-out 전에 제거되었거나 planning/history 문서로 이동했다
 - 동일 작업이 반복될 가능성이 높다면 skill화 여부가 검토되었거나, 아직 만들지 않는 이유가 남아 있다
 
 하네스 관련 작업은 아래 항목도 추가로 본다.

--- a/docs/operations/workflow-verification-runtime.md
+++ b/docs/operations/workflow-verification-runtime.md
@@ -4,7 +4,6 @@
 
 ## 목적과 범위
 
-- 대상 작업: `GRW-05`
 - 첫 대상 흐름: public ranking read
 - 포함 서비스: backend, client, db, prometheus, loki
 - 보조 서비스: promtail
@@ -13,7 +12,7 @@
 
 - workflow 루트에서 같은 compose 파일과 helper script로 기동
 - backend/client/public ranking endpoint/observability endpoint의 기본 health 확인
-- 후속 `GRB-03`, `GRC-04`, `GRW-06`이 붙을 interface와 포트 규칙 고정
+- 후속 deterministic seed, frontend smoke, observability evidence 작업이 재사용할 interface와 포트 규칙 고정
 
 현재 runtime은 아래를 아직 보장하지 않는다.
 
@@ -48,7 +47,7 @@
 - `start`는 compose build/up 전에 sibling `git-ranker`, `git-ranker-client` 저장소의 필수 파일을 먼저 검사한다.
 - `stop`은 컨테이너만 내리고 volume은 유지한다.
 - `reset`은 volume까지 제거해 db/metrics/log positions를 초기화한다.
-- `seed`는 현재 placeholder다. 실제 결정적 데이터 적재는 `GRB-03`에서 연결한다.
+- `seed`는 현재 placeholder다. 실제 결정적 데이터 적재는 별도 backend seed 작업에서 연결한다.
 - `verify`는 host 기준 endpoint에 대해 wait + health 확인을 수행한다.
 
 재사용 원칙:
@@ -116,8 +115,8 @@ helper는 `runtime/.env.example`의 값을 기본값으로 사용한다. 대표 
 - client의 sitemap/opengraph 같은 server-side fetch 경로는 `NEXT_PUBLIC_API_URL=http://localhost:8080`일 때 container 내부에서 동일하게 동작하지 않을 수 있다.
 - promtail은 Docker socket 기반으로 backend stdout JSON 로그를 수집한다. Docker 엔진 접근 제약이 있는 환경에서는 loki signal이 비어 있을 수 있다.
 
-## 다음 작업 연결
+## 향후 확장 포인트
 
-- `GRB-03`: `seed` 명령에 결정적 fixture 연결
-- `GRC-04`: ranking UI smoke와 pagination/tier filter를 runtime 위에서 실행
-- `GRW-06`: LogQL/PromQL query와 evidence summary 추가
+- `seed` 명령에 결정적 fixture를 연결한다.
+- ranking UI smoke와 pagination/tier filter를 runtime 위에서 실행한다.
+- LogQL/PromQL query와 evidence summary를 추가한다.

--- a/docs/quality-score/agent-readiness-scorecard.md
+++ b/docs/quality-score/agent-readiness-scorecard.md
@@ -1,6 +1,6 @@
 # Agent Readiness Scorecard
 
-이 문서는 `GRW-02`부터 사용하는 readiness 기준선 평가 축과 점수 규칙을 정의한다.
+이 문서는 readiness 기준선 평가 축과 점수 규칙을 정의한다.
 
 ## 평가 항목
 


### PR DESCRIPTION
## 1) Summary
- 요청 라우팅과 ambiguity interview 정책을 stable source of truth로 추가했습니다.
- stable harness 문서에 직접적인 work item ID가 남지 않도록 governance 규칙과 exec plan 작성 가드레일을 추가하고, evergreen 문서 표현을 일반화했습니다.

## 2) Linked Issue
- Closes #33
- Issue ID: `GRW-12`
- 대상 저장소: `git-ranker-workflow`

## 3) Harness Contract
- Request Type: `policy/governance`
- Context / Source of Truth:
  - `docs/architecture/harness-system-map.md`
  - `docs/operations/workflow-governance.md`
  - `docs/product/harness-roadmap.md`
  - `docs/product/work-item-catalog.md`
  - `docs/exec-plans/completed/2026-04-06-grw-11-harness-system-map.md`
- Write Scope:
  - `.codex/skills/issue-to-exec-plan/`
  - `docs/architecture/`
  - `docs/operations/`
  - `docs/quality-score/`
  - `docs/exec-plans/`
- Branch / Exec Plan:
  - `feat/grw-12-request-routing-ambiguity-policy`
  - `docs/exec-plans/completed/2026-04-06-grw-12-request-routing-ambiguity-policy.md`

## 4) Scope
- In Scope:
  - request routing / ambiguity interview policy 문서화
  - governance와 operations index 연결
  - stable source of truth의 task ID cleanup 규칙 추가
  - evergreen harness 문서의 직접적인 task ID 일반화
- Out of Scope:
  - 신규 에이전트 런타임 구현
  - backend/frontend 앱 코드 변경
  - intake skill, context pack registry, verification contract registry, review policy의 상세 구현

## 5) Outputs
- 변경된 문서 / 파일 / 디렉터리:
  - `docs/operations/request-routing-policy.md`
  - `docs/operations/workflow-governance.md`
  - `docs/operations/README.md`
  - `docs/architecture/harness-system-map.md`
  - `docs/operations/workflow-verification-runtime.md`
  - `docs/operations/observability-reference.md`
  - `docs/operations/frontend-runtime-reference.md`
  - `docs/quality-score/agent-readiness-scorecard.md`
  - `.codex/skills/issue-to-exec-plan/SKILL.md`
  - `docs/exec-plans/completed/2026-04-06-grw-12-request-routing-ambiguity-policy.md`
- 후속 작업이 바로 참조할 산출물:
  - request routing policy
  - stable source-of-truth task ID cleanup rule
  - updated GRW-12 close-out record

## 6) Verification Contract

### Docs / Policy

#### Check Item
- Name: request routing policy 본문 검토
- Command / Check: `sed -n '1,220p' docs/operations/request-routing-policy.md`
- Final Status: `PASS`
- Evidence: route category 3종, ambiguity signal, interview rules, exit condition, rejected semantics, example classification 5건을 확인함
- Failure / Exception:

#### Check Item
- Name: intake 용어와 governance 연결 확인
- Command / Check: `rg -n "대화|모호한 요청|즉시 실행 가능한 작업|ambiguity|interview|Rejected|fallback" docs/operations/request-routing-policy.md docs/operations/workflow-governance.md docs/operations/README.md`
- Final Status: `PASS`
- Evidence: request-routing-policy, workflow-governance, operations README에서 intake 핵심 용어와 rejected semantics가 함께 grep됨
- Failure / Exception:

#### Check Item
- Name: stable 문서 task ID cleanup 확인
- Command / Check: `rg -n "GRW-[0-9]+|GRW-S[0-9]+|GRB-[0-9]+|GRC-[0-9]+" docs/architecture docs/operations docs/domain docs/reliability docs/security docs/quality-score`
- Final Status: `PASS`
- Evidence: remaining matches are identifier-format rule and historical baseline only; evergreen harness 설명 문장에서는 직접적인 task ID가 제거됨
- Failure / Exception:

#### Check Item
- Name: whitespace / patch sanity
- Command / Check: `git diff --check` and `git diff --cached --check`
- Final Status: `PASS`
- Evidence: no whitespace or patch format errors
- Failure / Exception:

### Type / Lint / Test / Build

#### Check Item
- Name: docs-only change
- Command / Check: `N/A`
- Final Status: `N/A`
- Evidence: source-of-truth and skill documentation only
- Failure / Exception:

### Manual Check

#### Check Item
- Name: issue body 및 example 분류 수동 검토
- Command / Check: GitHub Issue `#33` body render 확인, example classification 5건 수동 검토
- Final Status: `PASS`
- Evidence: issue 본문 줄바꿈이 유지됐고, conversation / ambiguous / ready / rejected close-out 예시가 일관되게 분리됨
- Failure / Exception:

### Other Task-Specific Contract

#### Check Item
- Name: GRW-12 close-out 반영 확인
- Command / Check: `sed -n '1,240p' docs/exec-plans/completed/2026-04-06-grw-12-request-routing-ambiguity-policy.md`
- Final Status: `PASS`
- Evidence: 실제 write scope, verification, docs updated, cleanup rule 반영이 close-out 문서에 반영됨
- Failure / Exception:

## 7) Independent Review
- Implementer: `alexization (Codex)`
- Reviewer: `pending independent review`
- Reviewer Input: draft PR 기준으로 source-of-truth consistency, task ID cleanup rule, request routing semantics를 검토 예정
- Review Verdict: `pending`
- Findings / Change Requests: pending reviewer assignment

## 8) Source of Truth Update
- 업데이트한 문서:
  - `docs/operations/request-routing-policy.md`
  - `docs/operations/workflow-governance.md`
  - `docs/operations/README.md`
  - `docs/architecture/harness-system-map.md`
  - `docs/operations/workflow-verification-runtime.md`
  - `docs/operations/observability-reference.md`
  - `docs/operations/frontend-runtime-reference.md`
  - `docs/quality-score/agent-readiness-scorecard.md`
  - `.codex/skills/issue-to-exec-plan/SKILL.md`
  - `docs/exec-plans/completed/2026-04-06-grw-12-request-routing-ambiguity-policy.md`
- 업데이트하지 않은 문서와 사유:
  - `docs/product/`와 historical baseline snapshot은 tracking/history 자산이므로 task ID를 유지함

## 9) Feedback / Guardrail Follow-up
- 이번 작업에서 실제로 발생한 실패 / 예외 / 취약 지점:
  - stable source of truth 문서에 follow-up work item ID가 직접 남아 drift가 생김
  - branch 생성과 commit은 sandbox에서 `.git` 쓰기 제한 때문에 escalated path가 필요했음
- 새 guardrail 후보:
  - stable source of truth 문서의 task ID cleanup rule을 governance DoD와 exec plan 작성 skill에 반영
- 후속 Issue 또는 TODO:
  - intake skill / 후속 policy 작업에서도 stable 문서에 task ID를 다시 도입하지 않는지 review checklist에 포함 검토

## 10) Risks and Rollback
- Risks:
  - future docs 작업이 planning 문서의 task ID를 다시 evergreen 문장으로 가져오면 동일 drift가 재발할 수 있음
  - independent review가 아직 pending 상태임
- Rollback Plan:
  - PR revert 시 request routing policy 문서와 related governance/task-ID cleanup 문서 변경만 되돌리면 됨

## 11) Checklist
- [x] 연결된 Issue가 있다
- [x] Scope / Out of Scope가 적혀 있다
- [x] Write Scope가 적혀 있다
- [x] Verification 최종 상태와 예외가 기입되어 있다
- [ ] Implementer와 Reviewer가 분리되어 있다
- [x] Source of Truth 반영 여부가 적혀 있다
- [x] Feedback 또는 후속 guardrail 후보가 적혀 있다