### PR TITLE
[Task] GRW-14 tool boundary matrix와 write scope 거버넌스 정의

### DIFF
--- a/docs/architecture/context-pack-registry.md
+++ b/docs/architecture/context-pack-registry.md
@@ -10,6 +10,7 @@
 - 모든 pack은 공통 base context를 먼저 읽고, 그 다음 pack별 required docs를 연다.
 - optional docs는 issue, exec plan, hot file 탐색이 명시한 trigger가 있을 때만 연다.
 - 다른 pack의 required docs까지 필요해지면 임의로 pack을 합치지 않고 issue를 쪼개거나 exec plan을 갱신한다.
+- context pack selection만으로 tool/network/escalation 권한이 자동으로 열리지는 않는다. 구현 전에는 operations의 tool boundary policy로 access class를 따로 잠근다.
 - `docs/references/`와 generated snapshot은 default context가 아니다. 현재 source of truth가 부족하거나 생성 계약을 확인할 때만 연다.
 - target repo의 entrypoint 문서나 worktree가 없으면 `Context Ready`를 선언하지 않는다. 이 경우 worktree 준비 또는 `Blocked` 판단이 먼저다.
 

--- a/docs/architecture/harness-system-map.md
+++ b/docs/architecture/harness-system-map.md
@@ -119,7 +119,7 @@
 
 - request routing and ambiguity interview policy는 `Router`, `Interviewing`, `Rejected` semantics를 세분화한다.
 - [context-pack-registry.md](context-pack-registry.md)는 `Planned`에서 `Context Ready`로 가는 규칙을 registry 형태로 고정한다.
-- tool boundary matrix는 `Context Ready`와 `Implementing` 단계의 허용 도구와 write scope 경계를 상세화한다.
+- [../operations/tool-boundary-matrix.md](../operations/tool-boundary-matrix.md)는 `Context Ready`와 `Implementing` 단계의 허용 도구와 write scope 경계를 상세화한다.
 - verification contract registry는 `Verifying`, `Repairing`, `Blocked` semantics와 retry budget을 명시한다.
 - review policy는 `Reviewing` 단계의 reviewer input과 verdict 규칙을 구체화한다.
 - feedback ledger/policy는 `Feedback Pending`과 guardrail 승격 규칙을 고정한다.

--- a/docs/exec-plans/completed/2026-04-07-grw-14-tool-boundary-matrix-write-scope-governance.md
+++ b/docs/exec-plans/completed/2026-04-07-grw-14-tool-boundary-matrix-write-scope-governance.md
@@ -1,0 +1,107 @@
+# 2026-04-07-grw-14-tool-boundary-matrix-write-scope-governance
+
+- Issue ID: `GRW-14`
+- GitHub Issue: `#37`
+- Status: `Completed`
+- Repository: `git-ranker-workflow`
+- Branch Name: `feat/grw-14-tool-boundary-matrix-write-scope-governance`
+- Task Slug: `2026-04-07-grw-14-tool-boundary-matrix-write-scope-governance`
+
+## Problem
+
+`GRW-11`은 `Context Ready`와 `Implementing` 사이에 도구 경계와 write scope 통제가 필요하다고 정의했고, `GRW-13`은 task type별 최소 컨텍스트를 고정했다. 하지만 실제 구현 단계에서 task type마다 어떤 읽기 범위와 쓰기 범위와 네트워크 접근과 권한 상승이 허용되는지는 아직 source of truth로 잠겨 있지 않다.
+
+이 공백이 남아 있으면 같은 작업도 실행자마다 다른 도구를 사용하고, sibling 저장소를 불필요하게 읽거나, cross-repo 변경을 한 번에 시도하거나, 위험 명령과 권한 상승을 느슨하게 다루는 drift가 생길 수 있다. 후속 `GRW-15`, `GRW-16`, `GRW-17`, `GRW-18`, `GRW-S07`이 공유할 boundary 기준도 불안정해진다.
+
+## Why Now
+
+context pack registry는 "무엇을 읽을 수 있는가"를 잠갔지만, implementer 단계의 실제 통제력은 "무슨 도구를 어떤 범위로 쓸 수 있는가"가 정해져야 생긴다. `GRW-14`가 비어 있으면 같은 `workflow 문서 수정`, `backend 수정`, `frontend 수정`, `cross-repo planning` 작업도 read/write/network/escalation 판단이 매번 달라질 수 있다.
+
+또한 cross-repo 작업을 workflow 문서 PR과 앱 코드 PR로 분리한다는 governance 규칙도, 각 task type의 write scope template와 금지 사례가 있어야 실제 작업 단위로 재현된다. pilot issue와 boundary skill pack에 앞서 도구 경계와 write scope 거버넌스를 먼저 고정해야 한다.
+
+## Scope
+
+- `docs/operations/`에 tool boundary matrix source of truth를 추가한다.
+- task type별 read/write/network/escalation 허용 범위와 위험 명령 금지 규칙을 정의한다.
+- write scope template와 representative allow/deny 사례를 문서화한다.
+- 관련 architecture/operations 문서가 새 boundary policy를 참조하도록 갱신한다.
+- `GRW-14` close-out을 기록한다.
+
+## Non-scope
+
+- 샌드박스 구현 자체 변경
+- backend/frontend 앱 코드 변경
+- verification contract registry 상세 설계
+- boundary skill pack 작성
+
+## Write Scope
+
+- `docs/operations/`
+- `docs/architecture/`
+- `docs/exec-plans/`
+
+## Outputs
+
+- `docs/operations/tool-boundary-matrix.md`
+- task type별 boundary rule과 write scope template
+- operations/architecture의 boundary hook
+- `GRW-14` 실행 기록
+
+## Working Decisions
+
+- boundary matrix의 canonical source는 `docs/operations/`에 둔다.
+- task type 분류는 `GRW-13`의 `workflow 문서 수정`, `backend 수정`, `frontend 수정`, `cross-repo planning` 네 가지를 그대로 재사용한다.
+- 프롬프트 제약보다 도구 경계를 우선하고, cross-repo 작업은 기본적으로 `workflow 문서 PR`과 `앱 코드 PR`로 분리한다.
+- 위험 명령 금지와 escalation 기준은 "왜 필요한가", "허용 write scope 안인가", "더 좁은 대안이 없는가"를 함께 묻는 방식으로 정리한다.
+- context pack selection만으로 tool/network/escalation 권한이 자동으로 열리지 않으며, 구현 전 boundary policy를 한 번 더 잠근다.
+
+## Verification
+
+- `sed -n '1,320p' docs/operations/tool-boundary-matrix.md`
+  - 결과: boundary invariants, access class definitions, task matrix, dangerous command rules, escalation gate, write scope template, representative allow/deny 사례가 한 문서에 정리된 것을 확인했다.
+- `rg -n "read boundary|write boundary|network|escalation|dangerous command|cross-repo|write scope template" docs/operations/tool-boundary-matrix.md docs/operations/workflow-governance.md docs/architecture/harness-system-map.md docs/architecture/context-pack-registry.md docs/operations/README.md`
+  - 결과: 새 boundary policy의 핵심 용어와 governance/architecture hook이 함께 grep되는 것을 확인했다.
+- 대표 task 4종에 대한 allow/deny 사례 수동 검토
+  - 결과: `workflow 문서 수정`, `backend 수정`, `frontend 수정`, `cross-repo planning` 각각에 대해 허용/금지 사례를 표로 설명할 수 있음을 확인했다.
+- `git diff --check`
+  - 결과: whitespace 또는 patch formatting 오류가 없음을 확인했다.
+- `sed -n '1,80p' docs/operations/README.md` / `sed -n '34,60p' docs/operations/workflow-governance.md` / `sed -n '118,126p' docs/architecture/harness-system-map.md` / `sed -n '8,18p' docs/architecture/context-pack-registry.md`
+  - 결과: operations index, governance hook, architecture-level boundary handoff, context-pack handoff 규칙이 새 문서를 올바르게 참조하는 것을 확인했다.
+- GitHub Issue `#37` body render 확인
+  - 결과: issue 본문이 섹션과 줄바꿈을 유지한 채 생성된 것을 확인했다.
+
+## Evidence
+
+문서 작업이므로 브라우저, 로그, 메트릭 artifact는 필수는 아니다. 대신 아래를 근거로 남긴다.
+
+- task type별 read/write/network/escalation matrix
+- 위험 명령 금지 규칙과 escalation 판단 기준
+- write scope template와 representative allow/deny 사례
+- architecture/governance 연결 결과
+- GitHub Issue `#37` body 검증 결과
+
+## Risks or Blockers
+
+- sibling app 저장소의 실제 도구 제약은 repo-level guide에서 더 구체화될 수 있으므로, 이번 문서는 하네스 공통 기준을 먼저 고정하는 수준으로 유지해야 한다.
+- verification contract registry가 아직 없으므로, network/escalation 규칙은 "검증 자체의 허용"보다 "해당 task type에서 필요한 access class" 중심으로 정리해야 한다.
+
+## Next Preconditions
+
+- `GRW-15`: verification contract registry와 repair loop 기준 정의
+- `GRW-16`: dual-agent review policy 정의
+- `GRW-17`: failure-to-guardrail feedback loop 정의
+- `GRW-18`: workflow repo pilot issue로 새 흐름 1회 검증
+- `GRW-S07`: context-pack/boundary skill pack
+
+## Docs Updated
+
+- `docs/operations/tool-boundary-matrix.md`
+- `docs/operations/README.md`
+- `docs/operations/workflow-governance.md`
+- `docs/architecture/harness-system-map.md`
+- `docs/architecture/context-pack-registry.md`
+- `docs/exec-plans/completed/2026-04-07-grw-14-tool-boundary-matrix-write-scope-governance.md`
+
+## Skill Consideration
+
+이번 작업은 skill을 직접 작성하는 범위는 아니다. 대신 후속 `boundary-check` skill이 그대로 재사용할 수 있게 task type별 boundary rule, escalation 기준, write scope template를 source of truth로 먼저 고정한다.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -6,6 +6,7 @@
 
 - [workflow-governance.md](workflow-governance.md)
 - [request-routing-policy.md](request-routing-policy.md)
+- [tool-boundary-matrix.md](tool-boundary-matrix.md)
 - [workflow-verification-runtime.md](workflow-verification-runtime.md)
 - [manual-refresh-flow.md](manual-refresh-flow.md)
 - [daily-batch-flow.md](daily-batch-flow.md)

--- a/docs/operations/tool-boundary-matrix.md
+++ b/docs/operations/tool-boundary-matrix.md
@@ -1,0 +1,107 @@
+# Tool Boundary Matrix
+
+이 문서는 [../architecture/harness-system-map.md](../architecture/harness-system-map.md)의 `Context Ready -> Implementing` 구간에서 어떤 도구와 접근 범위를 허용할지 고정한다. [../architecture/context-pack-registry.md](../architecture/context-pack-registry.md)가 "무엇을 읽기 시작할 수 있는가"를 잠근다면, 이 문서는 "어떤 도구를 어떤 범위로 쓸 수 있는가"를 잠근다.
+
+공통 운영 규칙은 [workflow-governance.md](workflow-governance.md)를 따른다.
+
+## Boundary Invariants
+
+- 도구 경계는 프롬프트의 편의 지시보다 우선한다. 더 넓은 접근이 필요하면 즉흥적으로 진행하지 말고 exec plan 또는 issue 분해로 되돌린다.
+- 모든 실행 작업은 하나의 primary repo와 하나의 task type을 가진다. 이 기준이 흔들리면 `cross-repo planning`으로 되돌린다.
+- read boundary는 primary context pack과 issue/exec plan의 named input에서 시작한다. 다른 저장소나 다른 pack의 required docs가 필요해지면 boundary를 넓히지 말고 planning을 갱신한다.
+- write boundary는 "primary repo의 허용 경로"와 "control-plane artifact"를 분리해서 적는다. app repo 작업이라도 workflow의 exec plan, PR 본문, `.artifacts/<task-slug>/` 같은 control-plane artifact만 예외적으로 함께 쓸 수 있다.
+- network는 default allow가 아니다. issue publication, verification contract, evidence query, 공식 문서 확인처럼 목적이 명시된 경우에만 연다.
+- escalation은 마지막 수단이다. sandbox나 기본 도구로 충분한데 편의상 올리지 않는다.
+- cross-repo 작업은 기본적으로 `workflow 문서 PR`과 `앱 코드 PR`로 분리한다. 한 번의 구현 루프에서 여러 저장소 code diff를 동시에 만들지 않는다.
+- prompt, TODO, follow-up 메모가 write scope를 자동으로 넓혀 주지 않는다. 허용 경로는 issue와 exec plan이 canonical source다.
+
+## Access Class Definitions
+
+| Axis | Pass Signal | Fail Signal |
+| --- | --- | --- |
+| read boundary | primary context pack, named source, nearest hot file까지만 읽는다 | sibling repo 전체나 무관한 stable docs를 "혹시 필요할까" 수준으로 먼저 연다 |
+| write boundary | issue/exec plan에 적힌 경로와 control-plane artifact만 수정한다 | 다른 저장소 코드, unrelated stable docs, 선언되지 않은 대량 rewrite를 함께 건드린다 |
+| network | 목적이 있는 외부 시스템만 연다 | ad-hoc browsing, 무관한 원격 fetch, 설명 없는 dependency/network call을 실행한다 |
+| escalation | sandbox에서 막힌 필수 명령을 좁은 범위로 요청한다 | 더 좁은 대안이 있는데도 broad approval이나 convenience escalation을 요청한다 |
+
+## Task Matrix
+
+| Task type | Read boundary | Write boundary | Network | Escalation | Default denied |
+| --- | --- | --- | --- | --- | --- |
+| `workflow 문서 수정` | `git-ranker-workflow`의 `docs/`, `.github/`, `.codex/skills/`, active/completed exec plan, issue/exec plan named input까지만 읽는다. sibling app repo code tree는 planning 또는 repo-specific pack 없이 먼저 열지 않는다. | `git-ranker-workflow`의 문서/템플릿/skill 경로와 `docs/exec-plans/`만 쓴다. app repo code, app repo 설정 파일은 쓰지 않는다. | GitHub issue/PR 동기화, 공식 문서 확인, 문서 검증에 필요한 read-only 조회만 허용한다. package install, app runtime endpoint 호출은 기본 금지다. | `gh issue/pr` 발행, 허용 경로 안 문서 편집을 위해 꼭 필요한 명령만 올린다. 포트 바인딩, Docker, GUI 실행은 기본적으로 이 task type의 escalation 사유가 아니다. | sibling app code tree eager load, app repo 수정, repo-wide formatter 실행, destructive git 명령 |
+| `backend 수정` | target backend repo entry docs, issue/exec plan에 적힌 모듈/테스트/설정, surface cue에 매칭된 workflow 문서 최소 범위만 읽는다. frontend 내부 구현은 읽지 않는다. | backend repo의 허용 코드/테스트/설정 경로와 control-plane artifact만 쓴다. frontend repo 코드와 workflow stable docs 전체 수정은 금지다. | GitHub/공식 문서 조회, package registry, container/image fetch, verification contract에 적힌 local/runtime endpoint만 허용한다. 목적 없는 웹 탐색은 금지다. | backend build/test, Docker, 로컬 포트, repo write가 sandbox에서 막힐 때만 요청한다. 승인 범위는 backend repo와 declared verification command로 좁힌다. | frontend repo 수정, backend+frontend 동시 구현, secret 조회, broad filesystem write, destructive git 명령 |
+| `frontend 수정` | target frontend repo entry docs, issue/exec plan에 적힌 route/component/hook/test, surface cue에 맞는 workflow 문서 최소 범위만 읽는다. backend 내부 구현은 읽지 않는다. | frontend repo의 허용 route/UI/state/config/test 경로와 control-plane artifact만 쓴다. backend repo 코드와 workflow stable docs 전체 수정은 금지다. | GitHub/공식 문서 조회, package registry, verification contract에 적힌 local dev/runtime endpoint만 허용한다. 임의의 외부 자산 의존성 추가는 금지다. | frontend build/typecheck/lint/dev server/browser automation이 sandbox에서 막힐 때만 요청한다. 승인 범위는 frontend repo와 declared verification command로 좁힌다. | backend repo 수정, unrelated UI sweep, remote asset 의존성 추가, secret 조회, destructive git 명령 |
+| `cross-repo planning` | workflow planning docs와 영향받는 각 저장소의 entry docs, 필요한 contract 문서까지만 읽는다. 여러 저장소 code tree를 동시에 깊게 읽지 않는다. | workflow repo의 planning 문서, exec plan, issue/PR body file, 필요 시 `.artifacts/`만 쓴다. app repo code는 쓰지 않는다. | GitHub issue/PR metadata, repository inventory, 공식 문서 조회만 허용한다. package install, app runtime endpoint, CI rerun 같은 구현성 네트워크는 금지다. | GitHub issue/PR 생성·조회, read-only repo inspection처럼 planning을 닫는 데 필요한 명령만 올린다. app runtime/test 실행을 위한 escalation은 금지다. | multi-repo code diff 동시 작성, app repo 구현 착수, runtime 실행, destructive git 명령 |
+
+## Dangerous Command Rules
+
+아래는 기본적으로 `dangerous command`로 본다.
+
+- `git reset --hard`, `git checkout --`, `git clean -fd`, branch 삭제, history rewrite, blanket `rm -rf`, force push
+- 허용 경로를 넘는 repo-wide formatter, mass replace, bulk delete
+- 목적과 출처가 적히지 않은 remote script 실행, credential/secrets 조회, 무단 외부 업로드
+- 다른 저장소나 다른 task type 경계까지 한 번에 넓히는 broad automation
+
+예외 규칙:
+
+- 사용자가 직접 요청한 destructive 작업이거나, recoverable cleanup이면서 대상 경로와 이유가 좁게 고정된 경우만 별도 승인 후보가 된다.
+- 같은 목표를 read-only 명령, narrower path, non-escalated command로 달성할 수 있으면 dangerous command와 escalation을 선택하지 않는다.
+
+## Escalation Decision Gate
+
+escalation을 요청하기 전 아래 질문에 모두 `yes`여야 한다.
+
+1. 이 명령이 지금 task의 완료 조건이나 verification contract에 직접 필요하다.
+2. 명령의 read/write 대상이 현재 issue와 exec plan의 허용 범위 안에 있다.
+3. sandbox, local read-only command, connector, 더 좁은 명령으로는 같은 결과를 얻을 수 없다.
+4. 승인 요청 문장에 목적과 범위가 한 줄로 설명된다.
+
+하나라도 `no`면 escalation 대신 scope 축소, planning 갱신, 다른 도구 선택으로 되돌린다.
+
+## Write Scope Template
+
+issue와 exec plan에는 최소한 아래 형식으로 write scope를 적는다.
+
+```md
+## Write Scope
+- Primary repo: `git-ranker-workflow`
+- Allowed write paths:
+  - `docs/operations/`
+  - `docs/architecture/`
+- Control-plane artifacts:
+  - `docs/exec-plans/active/<task-slug>.md`
+  - `.artifacts/<task-slug>/` 필요 시
+- Explicitly forbidden:
+  - sibling app repo code
+  - named scope 밖 stable source of truth
+- Network / external systems:
+  - GitHub issue/PR metadata 확인
+  - 공식 문서 조회 필요 시
+- Escalation triggers:
+  - sandbox가 `gh issue create`를 막을 때
+  - declared verification command가 port/Docker 권한을 요구할 때
+```
+
+규칙:
+
+- `Allowed write paths`는 디렉터리 또는 파일 단위로 적고, "repo 전체"처럼 넓은 표현은 기본값으로 쓰지 않는다.
+- app repo 작업에서도 workflow control-plane artifact를 함께 쓰려면 별도 줄로 분리해서 적는다.
+- `Explicitly forbidden`에는 같은 요청에서 헷갈리기 쉬운 sibling repo나 adjacent stable docs를 적는다.
+- network가 전혀 필요 없으면 `없음`이라고 적는다. 침묵으로 생략하지 않는다.
+- escalation trigger는 실제로 올릴 수 있는 명령 class만 적고, 막연한 "필요 시 권한 요청" 표현은 쓰지 않는다.
+
+## Representative Allow / Deny Cases
+
+| Task type | Allow | Deny | Why |
+| --- | --- | --- | --- |
+| `workflow 문서 수정` | `docs/operations/tool-boundary-matrix.md`와 `docs/operations/workflow-governance.md`를 수정하고 issue body 렌더링을 확인한다 | `git-ranker-client`의 route 코드를 미리 읽거나 backend README를 같이 수정한다 | workflow-docs pack은 문서/템플릿 범위만 허용한다 |
+| `backend 수정` | backend service와 nearest test를 수정하고 workflow exec plan에 verification 결과를 남긴다 | 같은 턴에서 client component를 같이 수정한다 | app code 변경은 저장소별 issue/PR로 분리한다 |
+| `frontend 수정` | client route, hook, test를 수정하고 lint/typecheck/build를 실행한다 | backend repository/service 구현을 열어 직접 수정한다 | frontend task는 contract surface까지만 넘겨 읽고 backend 내부 구현은 분리한다 |
+| `cross-repo planning` | 두 저장소의 entry docs를 읽고 repo별 첫 issue/PR 분해 문서를 작성한다 | backend와 frontend 코드를 한 branch에서 동시에 수정한다 | planning 단계는 contract와 split을 고정할 뿐 구현을 시작하지 않는다 |
+
+## Boundary Failure Consequences
+
+- read boundary를 넘겼으면 추가 탐색을 멈추고 primary context pack 또는 issue 분해가 맞는지 다시 확인한다.
+- write boundary를 넘겼으면 임의로 계속 수정하지 말고, 범위 축소 또는 작업 분리를 먼저 한다.
+- network 또는 escalation이 문서화된 목적 없이 필요해지면 verification contract 또는 exec plan을 갱신하기 전에는 실행하지 않는다.
+- dangerous command가 필요해 보이면 대안이 없는지 먼저 적고, 사용자 승인 또는 별도 planning 없이는 진행하지 않는다.

--- a/docs/operations/workflow-governance.md
+++ b/docs/operations/workflow-governance.md
@@ -38,6 +38,14 @@
 - `docs/references/`와 generated snapshot은 default context가 아니다. 현재 source of truth가 부족하거나 생성 계약을 확인할 때만 연다.
 - target repo entry 문서나 worktree가 없으면 `Context Ready`를 선언하지 않고 `Blocked` 또는 준비 작업으로 되돌린다.
 
+## Tool Boundary 규칙
+
+- context pack을 고른 뒤 구현 전 [tool-boundary-matrix.md](tool-boundary-matrix.md)로 task type별 read boundary, write boundary, network, escalation class를 잠근다.
+- exec plan에는 최소한 primary repo, allowed write paths, control-plane artifact, explicitly forbidden path, network 필요 여부, escalation trigger를 적는다.
+- prompt나 follow-up 메모로 범위를 넓히지 않는다. issue와 exec plan에 없는 저장소 쓰기나 broad network access가 필요해지면 planning으로 되돌린다.
+- cross-repo planning은 여러 저장소를 읽을 수 있어도 app repo code write는 열지 않는다. app 구현이 필요하면 저장소별 issue/PR로 분리한다.
+- dangerous command와 broad escalation은 사용자 명시 요청 또는 좁게 복구 가능한 예외가 아니면 허용하지 않는다.
+
 ## 각 Issue에 반드시 들어가야 할 내용
 
 - 문제 정의
@@ -133,6 +141,7 @@
 - 이 Issue의 목표만 수행한다. 범위를 넓히지 않는다.
 - 선행조건이 충족되지 않았으면 임의로 우회 구현하지 말고 blocker를 먼저 정리한다.
 - 허용된 write scope 밖의 파일은 수정하지 않는다.
+- network나 escalation이 필요하면 목적과 범위를 exec plan 또는 최종 close-out에 남긴다.
 - source of truth 문서를 함께 업데이트하거나, 업데이트가 불필요한 이유를 남긴다.
 - 검증 명령과 최종 상태를 반드시 남기고, 실패나 예외가 있었다면 요약을 남긴다.
 - 새로 생긴 반복 절차가 있다면 skill 후보로 제안하되, 이번 Issue 범위를 넘는 구현은 하지 않는다.


### PR DESCRIPTION
## 1) Summary
- `docs/operations/tool-boundary-matrix.md`를 추가해 task type별 `read/write/network/escalation` 경계와 dangerous command 규칙을 고정했습니다.
- `GRW-11`, `GRW-13` 다음 단계로 implementer가 실제로 어떤 도구를 어떤 범위에서 쓸 수 있는지 source of truth로 잠가 `GRW-15`, `GRW-16`, `GRW-18`, `GRW-S07`이 같은 boundary 기준을 재사용할 수 있게 했습니다.

## 2) Linked Issue
- Closes #37
- Issue ID: `GRW-14`
- 대상 저장소: `git-ranker-workflow`

## 3) Harness Contract
- Request Type: `policy/governance`
- Context / Source of Truth:
  - `AGENTS.md`
  - `PLANS.md`
  - `docs/operations/workflow-governance.md`
  - `docs/product/harness-roadmap.md`
  - `docs/product/work-item-catalog.md`
  - `docs/architecture/harness-system-map.md`
  - `docs/architecture/context-pack-registry.md`
  - `docs/exec-plans/completed/2026-04-06-grw-11-harness-system-map.md`
  - `docs/exec-plans/completed/2026-04-07-grw-13-context-pack-registry.md`
- Write Scope:
  - `docs/operations/`
  - `docs/architecture/`
  - `docs/exec-plans/`
- Branch / Exec Plan:
  - `feat/grw-14-tool-boundary-matrix-write-scope-governance`
  - `docs/exec-plans/completed/2026-04-07-grw-14-tool-boundary-matrix-write-scope-governance.md`

## 4) Scope
- In Scope:
  - tool boundary matrix source of truth 작성
  - task type별 read/write/network/escalation 허용 범위와 dangerous command 규칙 정의
  - write scope template와 representative allow/deny 사례 정리
  - governance/architecture hook 연결
  - GRW-14 close-out 반영
- Out of Scope:
  - 샌드박스 구현 변경
  - backend/frontend 앱 코드 변경
  - verification contract registry 상세 설계
  - `boundary-check` skill 작성

## 5) Outputs
- 변경된 문서 / 파일 / 디렉터리:
  - `docs/operations/tool-boundary-matrix.md`
  - `docs/operations/README.md`
  - `docs/operations/workflow-governance.md`
  - `docs/architecture/harness-system-map.md`
  - `docs/architecture/context-pack-registry.md`
  - `docs/exec-plans/completed/2026-04-07-grw-14-tool-boundary-matrix-write-scope-governance.md`
- 후속 작업이 바로 참조할 산출물:
  - task type별 boundary matrix
  - write scope template
  - dangerous command / escalation gate 기준
  - architecture/governance boundary handoff

## 6) Verification Contract

### Docs / Policy

#### Check Item
- Name: Tool boundary matrix 본문 검토
- Command / Check: `sed -n '1,320p' docs/operations/tool-boundary-matrix.md`
- Final Status: `PASS`
- Evidence: boundary invariants, access class definitions, task matrix, dangerous command rules, escalation gate, write scope template, representative allow/deny 사례가 한 문서에 정리됨
- Failure / Exception:

#### Check Item
- Name: Governance / Architecture 연결 확인
- Command / Check: `rg -n "read boundary|write boundary|network|escalation|dangerous command|cross-repo|write scope template" docs/operations/tool-boundary-matrix.md docs/operations/workflow-governance.md docs/architecture/harness-system-map.md docs/architecture/context-pack-registry.md docs/operations/README.md`
- Final Status: `PASS`
- Evidence: 새 boundary policy의 핵심 용어와 governance/architecture hook가 함께 grep됨
- Failure / Exception:

#### Check Item
- Name: index / hook 본문 확인
- Command / Check: `sed -n '1,80p' docs/operations/README.md` / `sed -n '34,60p' docs/operations/workflow-governance.md` / `sed -n '118,126p' docs/architecture/harness-system-map.md` / `sed -n '8,18p' docs/architecture/context-pack-registry.md`
- Final Status: `PASS`
- Evidence: operations index, governance hook, architecture boundary handoff, context-pack handoff 규칙이 새 문서를 참조함
- Failure / Exception:

### Type / Lint / Test / Build

#### Check Item
- Name: patch hygiene
- Command / Check: `git diff --check`
- Final Status: `PASS`
- Evidence: whitespace 또는 patch formatting 오류 없음
- Failure / Exception:

### Manual Check

#### Check Item
- Name: representative allow/deny 사례 수동 검토
- Command / Check: 문서 수동 검토
- Final Status: `PASS`
- Evidence: `workflow 문서 수정`, `backend 수정`, `frontend 수정`, `cross-repo planning` 각각에 대해 허용/금지 사례를 표로 설명 가능함
- Failure / Exception:

#### Check Item
- Name: GitHub issue body render 확인
- Command / Check: GitHub Issue `#37` body 확인
- Final Status: `PASS`
- Evidence: issue 본문이 섹션과 줄바꿈을 유지함
- Failure / Exception:

### Other Task-Specific Contract

#### Check Item
- Name: 문서 변경 전용 작업
- Command / Check: `N/A`
- Final Status: `N/A`
- Evidence: 런타임 코드, 테스트, 빌드 파이프라인 변경 없음
- Failure / Exception:

## 7) Independent Review
- Implementer: `alexization (Codex)`
- Reviewer: `pending independent review`
- Reviewer Input: PR diff, verification 결과, completed exec plan
- Review Verdict: `pending`
- Findings / Change Requests: pending reviewer assignment

## 8) Source of Truth Update
- 업데이트한 문서:
  - `docs/operations/tool-boundary-matrix.md`
  - `docs/operations/README.md`
  - `docs/operations/workflow-governance.md`
  - `docs/architecture/harness-system-map.md`
  - `docs/architecture/context-pack-registry.md`
  - `docs/exec-plans/completed/2026-04-07-grw-14-tool-boundary-matrix-write-scope-governance.md`
- 업데이트하지 않은 문서와 사유:
  - `docs/product/*`: roadmap/catalog의 GRW-14 정의는 기존 항목만으로 충분해 추가 수정이 필요하지 않았음
  - `AGENTS.md`: write scope 규칙은 governance와 boundary matrix에서 canonical로 다루고 있어 루트 인덱스 변경은 생략함

## 9) Feedback / Guardrail Follow-up
- 이번 작업에서 실제로 발생한 실패 / 예외 / 취약 지점:
  - `gh auth status`는 invalid token을 보고하지만 실제 GitHub 작업은 별도 인증 경로로 동작할 수 있어 publish 전 상태 판단이 혼동될 수 있음
  - tool boundary가 없을 때 context selection 이후 implementer access class가 암묵적으로 남아 drift 위험이 있었음
- 새 guardrail 후보:
  - publish runbook에서 `gh auth status`와 실제 push/connector 동작 불일치 가능성을 별도 note로 관리할지 검토
  - 후속 `boundary-check` skill에서 write scope template와 escalation gate를 그대로 재사용
- 후속 Issue 또는 TODO:
  - `GRW-15`
  - `GRW-16`
  - `GRW-17`
  - `GRW-18`
  - `GRW-S07`

## 10) Risks and Rollback
- Risks:
  - sibling app 저장소의 더 세밀한 도구 제약은 repo-level guide에서 추가 정리될 수 있음
  - independent review가 아직 pending 상태임
- Rollback Plan:
  - `docs/operations/tool-boundary-matrix.md`와 관련 hook 변경만 revert하면 GRW-14 범위를 되돌릴 수 있음

## 11) Checklist
- [x] 연결된 Issue가 있다
- [x] Scope / Out of Scope가 적혀 있다
- [x] Write Scope가 적혀 있다
- [x] Verification 최종 상태와 예외가 기입되어 있다
- [ ] Implementer와 Reviewer가 분리되어 있다
- [x] Source of Truth 반영 여부가 적혀 있다
- [x] Feedback 또는 후속 guardrail 후보가 적혀 있다