### PR TITLE
[GRW-15] verification contract registry와 repair loop 기준 정의

### DIFF
--- a/docs/architecture/harness-system-map.md
+++ b/docs/architecture/harness-system-map.md
@@ -120,6 +120,6 @@
 - request routing and ambiguity interview policy는 `Router`, `Interviewing`, `Rejected` semantics를 세분화한다.
 - [context-pack-registry.md](context-pack-registry.md)는 `Planned`에서 `Context Ready`로 가는 규칙을 registry 형태로 고정한다.
 - [../operations/tool-boundary-matrix.md](../operations/tool-boundary-matrix.md)는 `Context Ready`와 `Implementing` 단계의 허용 도구와 write scope 경계를 상세화한다.
-- verification contract registry는 `Verifying`, `Repairing`, `Blocked` semantics와 retry budget을 명시한다.
+- [../operations/verification-contract-registry.md](../operations/verification-contract-registry.md)는 `Verifying`, `Repairing`, `Blocked` semantics와 retry budget을 명시한다.
 - review policy는 `Reviewing` 단계의 reviewer input과 verdict 규칙을 구체화한다.
 - feedback ledger/policy는 `Feedback Pending`과 guardrail 승격 규칙을 고정한다.

--- a/docs/exec-plans/completed/2026-04-07-grw-15-verification-contract-registry-repair-loop-policy.md
+++ b/docs/exec-plans/completed/2026-04-07-grw-15-verification-contract-registry-repair-loop-policy.md
@@ -1,0 +1,124 @@
+# 2026-04-07-grw-15-verification-contract-registry-repair-loop-policy
+
+- Issue ID: `GRW-15`
+- GitHub Issue: `#39`
+- Status: `Completed`
+- Repository: `git-ranker-workflow`
+- Branch Name: `feat/grw-15-verification-contract-registry-repair-loop-policy`
+- Task Slug: `2026-04-07-grw-15-verification-contract-registry-repair-loop-policy`
+
+## Problem
+
+`GRW-11`은 `Verifying`, `Repairing`, `Blocked` 상태의 상위 의미와 retry budget 필요성을 정의했고, `GRW-14`는 task type별 도구 경계와 escalation 규칙을 고정했다. 하지만 실제 작업에서 어떤 명령이 완료 판정을 내리는지, 실패 시 implementer가 reviewer에게 넘길 수 있는 repair loop 입력 형식이 무엇인지, 언제 `Blocked`로 멈춰야 하는지에 대한 registry는 아직 없다.
+
+이 공백이 남아 있으면 workflow 문서 작업과 backend/frontend 앱 작업이 서로 다른 검증 명령과 실패 해석을 사용하게 되고, review 이전에 필요한 verification report shape도 task마다 흔들린다. 후속 `GRW-16`, `GRW-17`, `GRW-S08`, `GRB-04`, `GRC-05`가 공유할 결정론적 완료 기준을 먼저 잠가야 한다.
+
+## Why Now
+
+하네스의 통제력은 "무엇을 읽는가"와 "무엇을 수정하는가"만으로는 완성되지 않는다. `Implementing -> Verifying -> Reviewing` 전이에서 어떤 명령을 통과해야 다음 상태로 넘어가는지, 실패하면 어떤 정보로 재작업을 지시할지를 먼저 고정해야 implementer와 reviewer의 역할 분리가 실제로 작동한다.
+
+또한 현재 workflow 저장소에는 cross-repo runtime 검증 기준이 일부 있고, backend/frontend 저장소에는 각자 build/test entrypoint가 존재할 수 있다. 이를 registry 형태로 먼저 정리해야 이후 repo-specific verification contract 정규화가 동일한 상위 규약을 재사용할 수 있다.
+
+## Scope
+
+- `docs/operations/`에 verification contract registry source of truth를 추가한다.
+- `workflow`, `backend`, `frontend` 기본 verification entrypoint, pass/fail semantics, evidence 필드를 정의한다.
+- repair loop 입력 형식, retry budget, `Blocked` 전환 기준, stop condition을 문서화한다.
+- 관련 architecture/operations/product 문서가 새 verification policy를 참조하도록 갱신한다.
+- `GRW-15` close-out을 기록한다.
+
+## Non-scope
+
+- backend/frontend 앱 코드 변경
+- 테스트 프레임워크 추가
+- dual-agent review policy 상세 설계
+- verification/review-loop skill pack 작성
+
+## Write Scope
+
+- Primary repo: `git-ranker-workflow`
+- Allowed write paths:
+  - `docs/operations/`
+  - `docs/architecture/`
+  - `docs/product/` 필요 시
+  - `docs/exec-plans/`
+- Control-plane artifacts:
+  - `docs/exec-plans/completed/2026-04-07-grw-15-verification-contract-registry-repair-loop-policy.md`
+  - `.artifacts/2026-04-07-grw-15-verification-contract-registry-repair-loop-policy/` 필요 시
+- Explicitly forbidden:
+  - sibling app repo code write
+  - declared scope 밖 stable source of truth mass update
+- Network / external systems:
+  - GitHub Issue body render 확인
+  - sibling repo remote source inspection 필요 시
+- Escalation triggers:
+  - 없음. 문서 작업과 read-only inspection 범위에서 처리한다.
+
+## Outputs
+
+- `docs/operations/verification-contract-registry.md`
+- verification report minimum shape와 repair loop policy
+- architecture/governance/product hook 갱신
+- `GRW-15` 실행 기록
+
+## Working Decisions
+
+- 이번 작업의 primary write repo는 `git-ranker-workflow`지만, read boundary는 `cross-repo planning`처럼 다뤄 backend/frontend의 current verification entrypoint를 확인한다.
+- sibling 저장소는 entry 문서, build/test script, verification 관련 공식 문서나 remote source까지만 읽고 구현 코드 수정으로는 확장하지 않는다.
+- registry는 repo-specific contract를 대체하지 않고, 각 저장소가 따라야 할 상위 completion semantics와 기본 entrypoint만 정의한다.
+- repair loop는 무한 재시도를 허용하지 않으며, retry budget 초과, canonical source 부재, 환경 선행조건 부재는 `Blocked`로 전환한다.
+- verification 결과는 reviewer가 diff와 함께 읽을 수 있도록 `command`, `final status`, `evidence`, `failure summary`, `next action`을 최소 필드로 가진다.
+
+## Verification
+
+- `sed -n '1,360p' docs/operations/verification-contract-registry.md`
+  - 결과: registry invariants, status vocabulary, contract selection rule, `workflow-docs`/`cross-repo-planning`/`workflow-runtime`/`backend-change`/`frontend-change` profile, verification report shape, repair loop policy가 한 문서에 정리된 것을 확인했다.
+- `rg -n "workflow-docs|backend-change|frontend-change|verification report|repair loop|retry budget|stop condition|Blocked" docs/operations/verification-contract-registry.md docs/architecture/harness-system-map.md docs/operations/workflow-governance.md docs/operations/tool-boundary-matrix.md docs/operations/README.md docs/product/work-item-catalog.md`
+  - 결과: verification contract registry의 핵심 용어와 architecture/governance/product hook이 함께 grep되는 것을 확인했다.
+- backend/frontend/workflow representative contract 수동 검토
+  - 결과: backend는 `../git-ranker/build.gradle`, `../git-ranker/docs/openapi/README.md`, 완료된 `GRB-02` exec plan을 기준으로 baseline/conditional command를 설명할 수 있었다.
+  - 결과: frontend는 `git-ranker-client` 원격 `README.md`, `package.json`, `.env.example`, 완료된 `GRC-03` exec plan과 `docs/operations/frontend-runtime-reference.md`를 기준으로 `lint`, `typecheck`, env 포함 `build` contract를 설명할 수 있었다.
+  - 결과: workflow는 `docs/operations/workflow-verification-runtime.md`와 완료된 `GRW-05` exec plan을 기준으로 runtime contract를 설명할 수 있었다.
+- `git diff --check`
+  - 결과: whitespace 또는 patch formatting 오류가 없음을 확인했다.
+- GitHub Issue `#39` body render 확인
+  - 결과: issue 본문이 섹션과 줄바꿈을 유지한 채 생성된 것을 확인했다.
+
+## Evidence
+
+문서 작업이므로 브라우저, 로그, 메트릭 artifact는 필수는 아니다. 대신 아래를 근거로 남긴다.
+
+- verification contract registry 본문
+- repo/task type별 기본 검증 명령과 evidence 필드
+- repair loop 입력 형식과 retry budget 기준
+- 관련 architecture/governance/product 연결 결과
+- backend local source: `../git-ranker/README.md`, `../git-ranker/build.gradle`, `../git-ranker/docs/openapi/README.md`
+- frontend remote source: `alexization/git-ranker-client`의 `develop` branch `README.md`, `package.json`, `.env.example`
+- GitHub Issue `#39` body 검증 결과
+
+## Risks or Blockers
+
+- 로컬에 `git-ranker-client` worktree가 없을 수 있으므로, frontend verification entrypoint는 remote source inspection과 existing workflow docs를 함께 대조해야 할 수 있다.
+- backend/frontend의 현재 명령이 repo 내부에서 일관되지 않다면, 이번 작업은 상위 registry를 먼저 고정하고 세부 정규화는 `GRB-04`, `GRC-05`로 넘겨야 한다.
+
+## Next Preconditions
+
+- `GRW-16`: dual-agent review policy 정의
+- `GRW-17`: failure-to-guardrail feedback loop 정의
+- `GRW-S08`: verification/review-loop skill pack
+- `GRB-04`: backend verification contract 정규화
+- `GRC-05`: frontend verification contract 정규화
+
+## Docs Updated
+
+- `docs/operations/verification-contract-registry.md`
+- `docs/operations/README.md`
+- `docs/operations/workflow-governance.md`
+- `docs/architecture/harness-system-map.md`
+- `docs/product/harness-roadmap.md`
+- `docs/product/work-item-catalog.md`
+- `docs/exec-plans/completed/2026-04-07-grw-15-verification-contract-registry-repair-loop-policy.md`
+
+## Skill Consideration
+
+이번 작업은 skill을 직접 작성하는 단계는 아니다. 대신 후속 `verification-contract-runner`, `repair-loop-triage`, `reviewer-handoff` skill이 재사용할 수 있도록 verification report shape와 retry/blocked semantics를 source of truth로 먼저 고정한다.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -7,6 +7,7 @@
 - [workflow-governance.md](workflow-governance.md)
 - [request-routing-policy.md](request-routing-policy.md)
 - [tool-boundary-matrix.md](tool-boundary-matrix.md)
+- [verification-contract-registry.md](verification-contract-registry.md)
 - [workflow-verification-runtime.md](workflow-verification-runtime.md)
 - [manual-refresh-flow.md](manual-refresh-flow.md)
 - [daily-batch-flow.md](daily-batch-flow.md)

--- a/docs/operations/verification-contract-registry.md
+++ b/docs/operations/verification-contract-registry.md
@@ -1,0 +1,296 @@
+# Verification Contract Registry
+
+이 문서는 [../architecture/harness-system-map.md](../architecture/harness-system-map.md)의 `Verifying`, `Repairing`, `Blocked` semantics를 실제 실행 규약으로 고정한다. [tool-boundary-matrix.md](tool-boundary-matrix.md)가 "어떤 도구를 어디까지 쓸 수 있는가"를 잠근다면, 이 문서는 "무슨 명령을 어떤 증거와 함께 통과해야 다음 상태로 갈 수 있는가"를 잠근다.
+
+관련 운영 규칙은 [workflow-governance.md](workflow-governance.md), workflow runtime 기준은 [workflow-verification-runtime.md](workflow-verification-runtime.md)를 따른다.
+
+## Registry Invariants
+
+- 모든 실행 작업은 `Verifying`에 들어가기 전에 정확히 하나의 primary contract profile을 exec plan에 적어야 한다.
+- contract profile은 repo-specific 세부 contract를 대체하지 않는다. 대신 각 저장소가 최소한 지켜야 할 기본 entrypoint, evidence, retry, `Blocked` semantics를 제공한다.
+- `passed`는 모든 required command가 성공하고 required evidence가 남았을 때만 성립한다.
+- required command가 실행은 되었지만 실패하면 overall status는 `failed`다. 이 경우 repair loop budget 안에서만 `Repairing`으로 되돌린다.
+- required command를 실행할 수 없거나 canonical source, 환경 선행조건, access boundary가 비어 있으면 overall status는 `blocked`다. 이 경우 추가 구현보다 blocker 정리가 먼저다.
+- optional 또는 conditional command는 생략 가능하지만, 생략 시에도 trigger 부재 또는 제외 이유를 verification report에 남겨야 한다.
+- reviewer에게 넘기는 verification report는 필수 산출물이다. report가 없거나 필드가 비어 있으면 verification은 끝난 것으로 보지 않는다.
+
+## Status Vocabulary
+
+| Level | Status | Meaning | Next state |
+| --- | --- | --- | --- |
+| command | `passed` | 명령이 기대한 종료 상태와 evidence를 남겼다 | 계속 진행 |
+| command | `failed` | 명령이 실행됐고 실패 원인이 현재 write scope 안에서 수리 가능하다 | `Repairing` |
+| command | `blocked` | 명령을 실행할 수 없거나 현재 issue 안에서 수리할 수 없는 선행조건이 비어 있다 | `Blocked` |
+| command | `skipped` | conditional command를 trigger 부재 또는 범위 제외 사유와 함께 생략했다 | 계속 진행 |
+| overall | `passed` | 모든 required command가 `passed`이고 report 필드가 완전하다 | `Reviewing` |
+| overall | `failed` | required command 중 하나 이상이 `failed`이고 repair budget이 남아 있다 | `Repairing` |
+| overall | `blocked` | required command 중 하나 이상이 `blocked`이거나 retry budget을 초과했다 | `Blocked` |
+
+## Contract Selection Rule
+
+- `workflow 문서 수정`은 `workflow-docs`를 기본으로 쓴다.
+- `cross-repo planning`은 `cross-repo-planning`을 기본으로 쓴다.
+- workflow 저장소가 runtime, compose, observability wiring을 직접 바꾸면 `workflow-runtime`을 쓴다.
+- `git-ranker` 코드/테스트/설정 변경은 `backend-change`를 쓴다.
+- `git-ranker-client` route/UI/state/config 변경은 `frontend-change`를 쓴다.
+- 하나의 issue에서 둘 이상의 profile이 동시에 필요해지면 contract를 합치지 말고 issue 분해 또는 exec plan 갱신으로 되돌린다.
+
+## Contract Profiles
+
+### `workflow-docs`
+
+대상:
+
+- `git-ranker-workflow`의 `docs/`, `.github/`, `.codex/skills/`, `docs/exec-plans/` 변경
+
+Required commands:
+
+- `sed -n '1,<N>p' <touched-doc>`
+- `rg -n "<핵심 용어 또는 hook>" <touched-docs-and-hooks>`
+- `git diff --check`
+
+Conditional commands:
+
+- 직접 링크된 이웃 문서가 바뀌는 경우 관련 `sed -n` 또는 `rg -n` 검토를 추가한다.
+- template 또는 GitHub 본문이 바뀌면 `gh issue view --json body` 또는 `gh pr view --json body`로 render를 확인한다.
+
+Pass signal:
+
+- 문서 본문에 scope, rule, hook, evidence semantics가 일관되게 반영되고 grep 결과로 인접 hook이 확인된다.
+
+Blocked triggers:
+
+- named source of truth가 없거나 서로 충돌해 새 정책 발명이 필요한 경우
+- touched doc의 인접 hook을 설명할 수 없을 정도로 context가 비어 있는 경우
+
+Evidence minimum:
+
+- 읽은 문서 경로
+- 핵심 grep 또는 수동 검토 결과
+- `git diff --check` 결과
+
+### `cross-repo-planning`
+
+대상:
+
+- workflow 저장소에만 쓰지만 sibling repo의 entrypoint, contract, verification surface를 읽어야 하는 planning 작업
+
+Required commands:
+
+- `sed -n '1,<N>p' <workflow-planning-doc>`
+- impacted repo entry doc 또는 공식 remote source 확인
+- `rg -n "<contract noun or repo name>" <planning-docs-and-hooks>`
+- `git diff --check`
+
+Conditional commands:
+
+- 로컬 worktree가 없으면 GitHub의 공식 file fetch 또는 issue metadata 확인으로 대체하되, 어떤 remote source를 썼는지 report에 적는다.
+
+Pass signal:
+
+- 각 impacted repo의 기본 entrypoint와 verification surface가 plan/source of truth에 명시되고, workflow 문서가 이를 정확히 인용한다.
+
+Blocked triggers:
+
+- impacted repo entry doc, worktree, 공식 remote source 중 어떤 것도 확보되지 않는 경우
+- 여러 저장소 구현을 한 issue에 묶어야만 verification을 설명할 수 있는 경우
+
+Evidence minimum:
+
+- impacted repo별로 읽은 entry doc 또는 remote source
+- workflow planning hook 검토 결과
+- `git diff --check` 결과
+
+### `workflow-runtime`
+
+대상:
+
+- `runtime/`, runtime runbook, compose wiring, cross-repo observability/runtime 문서 변경
+
+Required commands:
+
+- `docker compose --env-file runtime/.env.example -f runtime/compose.yaml config`
+- `./runtime/grw-runtime verify`
+
+Conditional commands:
+
+- stack이 기동되어 있지 않으면 `./runtime/grw-runtime start` 후 `verify`를 실행한다.
+- runtime 정리까지 이번 issue의 완료 조건에 포함되면 `./runtime/grw-runtime stop` 결과를 남긴다.
+
+Pass signal:
+
+- compose config 해석이 성공하고, runtime verify가 backend actuator, public API, client root, Prometheus ready, Loki ready를 통과한다.
+
+Blocked triggers:
+
+- sibling repo submodule/worktree가 비어 있어 runtime preflight를 만족할 수 없는 경우
+- Docker, 포트, compose 접근이 현재 task boundary 밖 환경 의존으로 막히는 경우
+
+Evidence minimum:
+
+- config 해석 결과 요약
+- `verify` endpoint 결과 요약
+- 필요 시 `start`/`stop` 실행 여부와 상태
+
+### `backend-change`
+
+대상:
+
+- `git-ranker`의 backend 코드, 테스트, 설정, OpenAPI snapshot entrypoint 변경
+
+Required commands:
+
+- `./gradlew test`
+- `./gradlew build`
+
+Conditional commands:
+
+- DB, Testcontainers, 배치, runtime wiring, public API end-to-end 영향을 건드리면 `./gradlew integrationTest`
+- line coverage gate를 직접 다루면 `./gradlew jacocoTestCoverageVerification`
+- public `/api/v1/**` contract를 바꾸면 `./gradlew generateOpenApiSpec`
+
+Pass signal:
+
+- unit/build baseline이 통과하고, trigger된 integration/coverage/OpenAPI 명령도 모두 성공한다.
+
+Blocked triggers:
+
+- required integration test에 필요한 Docker 또는 runtime 선행조건이 없고 현재 issue 안에서 복구할 수 없는 경우
+- OpenAPI snapshot을 갱신해야 하지만 source contract 또는 출력 경로가 잠겨 있지 않은 경우
+
+Evidence minimum:
+
+- baseline `test`, `build` 결과
+- conditional command 실행 여부와 trigger 근거
+- 실패 시 preflight 또는 환경 상태 요약
+
+Source notes:
+
+- baseline Gradle entrypoint는 `git-ranker/build.gradle`을 기준으로 한다.
+- OpenAPI regeneration entrypoint는 `git-ranker/docs/openapi/README.md`를 기준으로 한다.
+
+### `frontend-change`
+
+대상:
+
+- `git-ranker-client`의 route, UI, state, config, build/runtime env 변경
+
+Required commands:
+
+- `npm run lint`
+- `npx tsc --noEmit`
+- `NEXT_PUBLIC_BASE_URL=http://localhost:3000 NEXT_PUBLIC_API_URL=http://localhost:8080 npm run build`
+
+Conditional commands:
+
+- route runtime, locale redirect, CSP, browser-only behavior를 직접 바꾸면 local dev 또는 preview 확인 명령을 exec plan에 추가한다.
+- remote source inspection만 가능한 경우 현재 repo README와 package manifest를 함께 근거로 남긴다.
+
+Pass signal:
+
+- lint, typecheck, build가 모두 성공하고 required `NEXT_PUBLIC_*` env 전제가 report에 남는다.
+
+Blocked triggers:
+
+- required public env 값이나 runtime origin 정책이 잠겨 있지 않은 경우
+- local worktree와 공식 remote source 모두 없어 current entrypoint를 확인할 수 없는 경우
+
+Evidence minimum:
+
+- `lint`, `tsc`, `build` 결과
+- 사용한 `NEXT_PUBLIC_BASE_URL`, `NEXT_PUBLIC_API_URL` 값
+- conditional runtime 확인 여부와 사유
+
+Source notes:
+
+- 기본 명령과 env 전제는 `git-ranker-client/README.md`, `git-ranker-client/package.json`, `git-ranker-client/.env.example`를 기준으로 한다.
+
+## Verification Report Shape
+
+verification report는 exec plan, PR 본문, `.artifacts/<task-slug>/summary.md` 중 최소 한 곳에 아래 필드를 남긴다.
+
+```md
+## Verification Report
+- Contract profile: `frontend-change`
+- Overall status: `passed`
+- Preconditions:
+  - `NEXT_PUBLIC_BASE_URL=http://localhost:3000`
+  - `NEXT_PUBLIC_API_URL=http://localhost:8080`
+- Command: `npm run lint`
+  - Status: `passed`
+  - Evidence: 성공
+- Command: `npx tsc --noEmit`
+  - Status: `passed`
+  - Evidence: 성공
+- Command: `NEXT_PUBLIC_BASE_URL=http://localhost:3000 NEXT_PUBLIC_API_URL=http://localhost:8080 npm run build`
+  - Status: `passed`
+  - Evidence: 성공
+- Failure summary: 없음
+- Next action: reviewer handoff
+```
+
+필수 필드:
+
+- `Contract profile`
+- `Overall status`
+- `Preconditions` 또는 relevant env/runtime 전제
+- command별 `Status`
+- command별 `Evidence`
+- `Failure summary`
+- `Next action`
+
+추가 규칙:
+
+- conditional command를 생략하면 `Status: skipped`와 생략 이유를 같이 적는다.
+- reviewer는 최신 report 하나만 읽어도 전체 required command 상태를 판단할 수 있어야 한다.
+- 이전 repair attempt의 실패 로그는 남길 수 있지만, 최종 report에는 "현재 최신 기준에서 어떤 명령이 통과했는가"가 다시 요약돼야 한다.
+
+## Repair Loop Policy
+
+### Entry Criteria
+
+아래 중 하나가 생기면 `Repairing`으로 들어간다.
+
+- required command가 `failed`다.
+- required evidence가 비어 있다.
+- reviewer가 "diff와 verification report가 불일치한다"고 판단했다.
+
+아래 중 하나면 곧바로 `Blocked`다.
+
+- required command가 `blocked`다.
+- canonical source, repo entry doc, required worktree/remote source가 없다.
+- 필요한 env, Docker, 포트, credential, external dependency가 현재 issue 범위 밖이다.
+
+### Retry Budget
+
+- 기본 budget은 "첫 실패 후 최대 2회의 repair attempt"다.
+- 각 repair attempt는 실패 원인을 좁히는 실제 수정 또는 환경 교정 하나와, 그에 대응하는 command 재실행을 함께 남겨야 한다.
+- 같은 root cause가 2회 repair 뒤에도 남아 있으면 더 오래 밀어붙이지 말고 `Blocked` 또는 후속 issue split으로 전환한다.
+- 새로운 failure class가 추가로 드러나면 budget을 리셋하지 않는다. 현재 issue에서 안전하게 줄일 수 없는 범위 확장은 follow-up으로 넘긴다.
+
+### Re-run Rule
+
+- repair 후에는 최소한 실패했던 required command를 다시 실행한다.
+- failure가 baseline command에 걸려 있었으면 그 아래 conditional command를 통과로 간주하지 않는다. 최신 report에서 다시 상태를 적어야 한다.
+- reviewer handoff 전에는 latest report 기준으로 모든 required command가 `passed`여야 한다.
+
+### Blocked / Stop Conditions
+
+| Signal | Meaning | Required action |
+| --- | --- | --- |
+| retry budget exhausted | 같은 issue에서 수리 루프를 더 돌려도 신호가 나아지지 않는다 | `Blocked` 또는 follow-up issue split |
+| missing canonical source | 어떤 명령을 정답으로 써야 하는지 source of truth가 없다 | planning 또는 source-of-truth update 먼저 |
+| environment prerequisite absent | Docker, env, port, credential, runtime이 현재 범위 밖이다 | 현재 issue는 `Blocked`로 정리 |
+| access boundary conflict | 허용되지 않은 저장소/경로/네트워크가 필요하다 | boundary 갱신 또는 issue 분해 |
+| evidence mismatch | 명령 결과와 diff 또는 문서 서술이 서로 맞지 않는다 | 재검증 후 report 갱신 |
+
+## Reviewer Handoff Minimum
+
+reviewer에게 넘길 때는 최소한 아래 입력이 함께 있어야 한다.
+
+- exec plan 경로
+- latest verification report
+- touched diff 요약
+- 남은 리스크 또는 conditional command 생략 사유
+
+이 입력이 비어 있으면 review 단계로 넘어간 것으로 보지 않는다.

--- a/docs/operations/workflow-governance.md
+++ b/docs/operations/workflow-governance.md
@@ -41,6 +41,7 @@
 ## Tool Boundary 규칙
 
 - context pack을 고른 뒤 구현 전 [tool-boundary-matrix.md](tool-boundary-matrix.md)로 task type별 read boundary, write boundary, network, escalation class를 잠근다.
+- verification 단계에 들어가기 전 [verification-contract-registry.md](verification-contract-registry.md)에서 primary contract profile을 고르고, conditional command나 repo-specific override는 exec plan에 적는다.
 - exec plan에는 최소한 primary repo, allowed write paths, control-plane artifact, explicitly forbidden path, network 필요 여부, escalation trigger를 적는다.
 - prompt나 follow-up 메모로 범위를 넓히지 않는다. issue와 exec plan에 없는 저장소 쓰기나 broad network access가 필요해지면 planning으로 되돌린다.
 - cross-repo planning은 여러 저장소를 읽을 수 있어도 app repo code write는 열지 않는다. app 구현이 필요하면 저장소별 issue/PR로 분리한다.
@@ -76,6 +77,7 @@
 하네스 관련 PR에서는 가능하면 아래 증거를 남긴다.
 
 - 명령 실행 결과 요약 또는 artifact 위치
+- verification report 최소 필드: contract profile, command별 status, 핵심 evidence, failure summary, next action
 - 브라우저 증거: screenshot, trace, video
 - 로그 증거: LogQL 결과 또는 로그 요약
 - 메트릭 증거: PromQL 결과 또는 지표 캡처
@@ -142,6 +144,7 @@
 - 선행조건이 충족되지 않았으면 임의로 우회 구현하지 말고 blocker를 먼저 정리한다.
 - 허용된 write scope 밖의 파일은 수정하지 않는다.
 - network나 escalation이 필요하면 목적과 범위를 exec plan 또는 최종 close-out에 남긴다.
+- verification failure가 나면 registry의 retry budget 안에서만 repair loop를 돌리고, budget 초과나 missing canonical source는 `Blocked` 또는 후속 planning으로 넘긴다.
 - source of truth 문서를 함께 업데이트하거나, 업데이트가 불필요한 이유를 남긴다.
 - 검증 명령과 최종 상태를 반드시 남기고, 실패나 예외가 있었다면 요약을 남긴다.
 - 새로 생긴 반복 절차가 있다면 skill 후보로 제안하되, 이번 Issue 범위를 넘는 구현은 하지 않는다.

--- a/docs/product/harness-roadmap.md
+++ b/docs/product/harness-roadmap.md
@@ -29,7 +29,7 @@
 3. 실행 가능한 작업만 exec plan으로 고정하고, 저장소와 write scope를 명시한다.
 4. task type에 맞는 context pack만 Agent에 제공한다.
 5. Implementer Agent는 허용된 도구 경계 안에서만 작업한다.
-6. 정해진 verification contract의 명령이 통과해야 다음 단계로 넘어간다.
+6. verification contract registry에 정의된 명령이 통과해야 다음 단계로 넘어간다.
 7. Reviewer Agent는 구현 diff와 검증 결과를 검토하고, 통과 또는 수정 요청을 결정한다.
 8. 실패한 작업은 feedback ledger에 남기고 다음 가드레일 후보로 전환한다.
 

--- a/docs/product/work-item-catalog.md
+++ b/docs/product/work-item-catalog.md
@@ -174,7 +174,7 @@
 - 저장소: `git-ranker`
 - 선행조건: `GRW-15`
 - 권장 write scope: backend 검증 문서, build/test entrypoint, 필요 최소한의 preflight
-- 기본 결정: 행동 변경 없이 검증 명령과 실패 의미를 명확히 하는 것이 우선이다.
+- 기본 결정: 행동 변경 없이 검증 명령과 실패 의미를 명확히 하는 것이 우선이다. 상위 completion semantics는 verification contract registry를 따른다.
 - 핵심 작업: 현재 backend 검증 명령, fail-fast 조건, 환경 전제, 결과 해석 기준을 contract에 맞게 정리한다.
 - 비범위: 새 기능 구현
 - 산출물: backend verification contract, 필요한 문서/스크립트 정리
@@ -187,7 +187,7 @@
 - 저장소: `git-ranker-client`
 - 선행조건: `GRW-15`
 - 권장 write scope: frontend 검증 문서, build/lint/typecheck entrypoint
-- 기본 결정: `lint`, `typecheck`, `build`를 안정적인 완료 조건으로 먼저 고정한다.
+- 기본 결정: `lint`, `typecheck`, `build`를 안정적인 완료 조건으로 먼저 고정한다. 상위 completion semantics는 verification contract registry를 따른다.
 - 핵심 작업: 현재 frontend 검증 명령, 필수 env, 실패 의미, 수동 확인이 필요한 공백을 contract에 맞게 정리한다.
 - 비범위: UI 개편
 - 산출물: frontend verification contract, 필요한 문서/스크립트 정리


### PR DESCRIPTION
## 1) Summary
- `docs/operations/verification-contract-registry.md`를 추가해 workflow/backend/frontend 기본 verification contract, verification report shape, repair loop policy를 고정했습니다.
- `GRW-15`의 completion semantics를 `workflow-governance`, `harness-system-map`, roadmap, work item catalog에 연결해 후속 `GRW-16`, `GRB-04`, `GRC-05`가 같은 기준을 재사용하도록 정리했습니다.

## 2) Linked Issue
- Closes #39
- Issue ID: `GRW-15`
- 대상 저장소: `git-ranker-workflow`

## 3) Harness Contract
- Request Type: `verification-contract`
- Context / Source of Truth:
  - `AGENTS.md`
  - `PLANS.md`
  - `docs/operations/workflow-governance.md`
  - `docs/architecture/harness-system-map.md`
  - `docs/architecture/context-pack-registry.md`
  - `docs/operations/tool-boundary-matrix.md`
  - `docs/operations/workflow-verification-runtime.md`
  - `../git-ranker/build.gradle`
  - `../git-ranker/docs/openapi/README.md`
  - `alexization/git-ranker-client` `develop`의 `README.md`, `package.json`, `.env.example`
- Write Scope:
  - `docs/operations/`
  - `docs/architecture/`
  - `docs/product/`
  - `docs/exec-plans/`
- Branch / Exec Plan:
  - `feat/grw-15-verification-contract-registry-repair-loop-policy`
  - `docs/exec-plans/completed/2026-04-07-grw-15-verification-contract-registry-repair-loop-policy.md`

## 4) Scope
- In Scope:
  - verification contract registry 문서 추가
  - verification report 최소 필드, retry budget, `Blocked` 전환 기준 정의
  - governance/architecture/product hook 정렬
  - GRW-15 exec plan close-out
- Out of Scope:
  - backend/frontend 앱 코드 변경
  - 테스트 프레임워크 추가
  - dual-agent review policy 상세 설계
  - verification/review-loop skill pack 작성

## 5) Outputs
- 변경된 문서 / 파일 / 디렉터리:
  - `docs/operations/verification-contract-registry.md`
  - `docs/operations/README.md`
  - `docs/operations/workflow-governance.md`
  - `docs/architecture/harness-system-map.md`
  - `docs/product/harness-roadmap.md`
  - `docs/product/work-item-catalog.md`
  - `docs/exec-plans/completed/2026-04-07-grw-15-verification-contract-registry-repair-loop-policy.md`
- 후속 작업이 바로 참조할 산출물:
  - task profile별 verification contract profile
  - verification report shape
  - repair loop / retry budget / `Blocked` semantics

## 6) Verification Contract

### Docs / Policy

#### Check Item
- Name: registry 본문 확인
- Command / Check: `sed -n '1,360p' docs/operations/verification-contract-registry.md`
- Final Status: `PASS`
- Evidence: registry invariants, status vocabulary, contract profiles, verification report shape, repair loop policy가 한 문서에 정리됨
- Failure / Exception:

#### Check Item
- Name: hook 연결 grep 확인
- Command / Check: `rg -n "workflow-docs|backend-change|frontend-change|verification report|repair loop|retry budget|stop condition|Blocked" docs/operations/verification-contract-registry.md docs/architecture/harness-system-map.md docs/operations/workflow-governance.md docs/operations/tool-boundary-matrix.md docs/operations/README.md docs/product/work-item-catalog.md`
- Final Status: `PASS`
- Evidence: verification contract registry 핵심 용어와 architecture/governance/product hook이 함께 grep됨
- Failure / Exception:

#### Check Item
- Name: GitHub issue body render 확인
- Command / Check: `gh issue view --repo alexization/git-ranker-workflow 39 --json body`
- Final Status: `PASS`
- Evidence: issue `#39` 본문이 섹션과 줄바꿈을 유지한 채 렌더링됨
- Failure / Exception:

### Type / Lint / Test / Build

#### Check Item
- Name: 문서 작업 전용
- Command / Check: `N/A`
- Final Status: `N/A`
- Evidence: 이번 PR은 workflow source-of-truth 문서 변경만 포함
- Failure / Exception:

### Manual Check

#### Check Item
- Name: backend/frontend/workflow representative contract 수동 검토
- Command / Check: local `git-ranker` source + remote `git-ranker-client` source + existing workflow docs 대조
- Final Status: `PASS`
- Evidence: backend baseline/conditional command, frontend `lint`/`typecheck`/env 포함 `build`, workflow runtime verify contract를 각각 설명 가능함을 확인
- Failure / Exception: 로컬 `git-ranker-client` worktree가 없어 frontend는 GitHub remote source inspection으로 대체

### Other Task-Specific Contract

#### Check Item
- Name: patch formatting 확인
- Command / Check: `git diff --check`
- Final Status: `PASS`
- Evidence: whitespace 또는 patch formatting 오류 없음
- Failure / Exception:

## 7) Independent Review
- Implementer: `Codex (GPT-5)`
- Reviewer: `Pending independent review`
- Reviewer Input:
  - completed exec plan
  - latest verification results in this PR
  - changed source-of-truth docs
- Review Verdict: `PENDING`
- Findings / Change Requests:
  - draft PR 단계에서 독립 리뷰 대기

## 8) Source of Truth Update
- 업데이트한 문서:
  - `docs/operations/verification-contract-registry.md`
  - `docs/operations/README.md`
  - `docs/operations/workflow-governance.md`
  - `docs/architecture/harness-system-map.md`
  - `docs/product/harness-roadmap.md`
  - `docs/product/work-item-catalog.md`
  - `docs/exec-plans/completed/2026-04-07-grw-15-verification-contract-registry-repair-loop-policy.md`
- 업데이트하지 않은 문서와 사유:
  - repo-specific verification 문서는 이번 PR 범위 밖이며 `GRB-04`, `GRC-05`에서 정규화 예정

## 9) Feedback / Guardrail Follow-up
- 이번 작업에서 실제로 발생한 실패 / 예외 / 취약 지점:
  - 로컬 `git-ranker-client` worktree가 없어 frontend verification entrypoint는 공식 remote source inspection으로 확인
  - `gh auth status`의 default token은 invalid였지만, remote push와 GitHub app 기반 PR 생성으로 publish는 진행 가능
- 새 guardrail 후보:
  - publish 단계에서 `gh auth status` fallback 경로를 skill 또는 운영 문서에 보강할지 검토 필요
- 후속 Issue 또는 TODO:
  - `GRW-16`
  - `GRB-04`
  - `GRC-05`

## 10) Risks and Rollback
- Risks:
  - backend/frontend repo 내부 명령이 이후 정규화 과정에서 더 구체화되면 registry wording 조정이 필요할 수 있음
  - frontend contract는 현재 remote source inspection을 포함하므로, 로컬 worktree 기준과 차이가 생기면 후속 보정이 필요할 수 있음
- Rollback Plan:
  - 이 PR revert로 verification contract registry와 hook 변경을 함께 되돌리고, 기존 governance/harness 문서 기준으로 복귀

## 11) Checklist
- [x] 연결된 Issue가 있다
- [x] Scope / Out of Scope가 적혀 있다
- [x] Write Scope가 적혀 있다
- [x] Verification 최종 상태와 예외가 기입되어 있다
- [ ] Implementer와 Reviewer가 분리되어 있다
- [x] Source of Truth 반영 여부가 적혀 있다
- [x] Feedback 또는 후속 guardrail 후보가 적혀 있다