### PR TITLE
[GRW-16] dual-agent review policy 정의

### DIFF
--- a/docs/architecture/harness-system-map.md
+++ b/docs/architecture/harness-system-map.md
@@ -121,5 +121,5 @@
 - [context-pack-registry.md](context-pack-registry.md)는 `Planned`에서 `Context Ready`로 가는 규칙을 registry 형태로 고정한다.
 - [../operations/tool-boundary-matrix.md](../operations/tool-boundary-matrix.md)는 `Context Ready`와 `Implementing` 단계의 허용 도구와 write scope 경계를 상세화한다.
 - [../operations/verification-contract-registry.md](../operations/verification-contract-registry.md)는 `Verifying`, `Repairing`, `Blocked` semantics와 retry budget을 명시한다.
-- review policy는 `Reviewing` 단계의 reviewer input과 verdict 규칙을 구체화한다.
+- [../operations/dual-agent-review-policy.md](../operations/dual-agent-review-policy.md)는 `Reviewing` 단계의 reviewer input, verdict, repair loop, evidence rule을 구체화한다.
 - feedback ledger/policy는 `Feedback Pending`과 guardrail 승격 규칙을 고정한다.

--- a/docs/exec-plans/completed/2026-04-07-grw-16-dual-agent-review-policy.md
+++ b/docs/exec-plans/completed/2026-04-07-grw-16-dual-agent-review-policy.md
@@ -1,0 +1,119 @@
+# 2026-04-07-grw-16-dual-agent-review-policy
+
+- Issue ID: `GRW-16`
+- GitHub Issue: `#41`
+- Status: `Completed`
+- Repository: `git-ranker-workflow`
+- Branch Name: `feat/grw-16-dual-agent-review-policy`
+- Task Slug: `2026-04-07-grw-16-dual-agent-review-policy`
+
+## Problem
+
+`GRW-11`은 `Reviewing` 상태와 implementer/reviewer 분리 원칙을 정의했고, `GRW-15`는 reviewer handoff 전에 필요한 verification report minimum을 고정했다. 하지만 reviewer가 정확히 어떤 입력을 받아야 하는지, 어떤 기준으로 승인, 수정 요청, `Blocked`를 판단하는지, review 결과를 어디에 어떤 evidence 형태로 남겨야 하는지는 아직 source of truth로 잠겨 있지 않다.
+
+이 공백이 남아 있으면 implementer와 reviewer가 같은 diff를 두고도 서로 다른 승인 기준을 쓰게 되고, PR template의 `Independent Review` 섹션과 이후 `GRW-S08` skill pack이 재사용할 canonical handoff 규칙도 흔들린다. 구현 Agent가 자기 결과를 승인하지 못하게 하려면 reviewer의 입력, 판단 기준, 수정 요청 루프를 먼저 고정해야 한다.
+
+## Why Now
+
+하네스의 `Implementing -> Verifying -> Reviewing -> Feedback` 흐름은 verification contract만으로 완성되지 않는다. verification이 통과한 뒤에도 reviewer가 무엇을 확인해야 하는지, 어떤 경우에 repair로 되돌리고 어떤 경우에 feedback close-out으로 넘기는지가 문서로 잠겨 있어야 실제로 dual-agent review가 운영된다.
+
+또한 이미 PR template과 verification registry에는 reviewer input과 독립 review 섹션이 들어가 있다. `GRW-16`은 이 필드들이 참조할 canonical review policy를 제공해, 이후 `reviewer-handoff` skill과 pilot issue가 같은 handoff shape와 verdict semantics를 사용하게 만드는 선행 작업이다.
+
+## Scope
+
+- `docs/operations/`에 dual-agent review policy source of truth를 추가한다.
+- implementer/reviewer 책임 분리, reviewer minimum input, review verdict 종류와 pass/fail semantics를 정의한다.
+- 수정 요청 loop, self-approval 금지, review evidence 규칙과 draft checklist를 문서화한다.
+- 관련 architecture/operations/product 문서가 새 review policy를 참조하도록 갱신한다.
+- `GRW-16` close-out을 기록한다.
+
+## Non-scope
+
+- 자동 PR review bot 구현
+- `GRW-S08` skill pack 작성
+- backend/frontend 앱 코드 변경
+- verification contract 자체 변경
+- `.github/` template 구조 변경
+
+## Write Scope
+
+- Primary repo: `git-ranker-workflow`
+- Allowed write paths:
+  - `docs/operations/`
+  - `docs/architecture/`
+  - `docs/product/` 필요 시
+  - `docs/exec-plans/`
+- Control-plane artifacts:
+  - `docs/exec-plans/completed/2026-04-07-grw-16-dual-agent-review-policy.md`
+  - `.artifacts/2026-04-07-grw-16-dual-agent-review-policy/` 필요 시
+- Explicitly forbidden:
+  - `.github/` template 구조 변경
+  - sibling app repo code write
+  - scope 밖 stable source of truth mass update
+- Network / external systems:
+  - GitHub Issue body render 확인
+- Escalation triggers:
+  - 없음. 문서 작업 범위에서 처리한다.
+
+## Outputs
+
+- `docs/operations/dual-agent-review-policy.md`
+- reviewer handoff minimum, verdict semantics, review evidence rule, draft checklist
+- architecture/operations/product hook 갱신
+- `GRW-16` 실행 기록
+
+## Working Decisions
+
+- 이번 작업의 primary context pack은 `workflow-docs`다.
+- dual-agent review의 canonical source는 `docs/operations/dual-agent-review-policy.md`에 두고, skill이나 template는 후속 `GRW-S08`에서 이 문서를 참조하는 thin layer로만 만든다.
+- reviewer verdict vocabulary는 state machine과 직접 대응되도록 `approved`, `changes-requested`, `blocked` 세 가지로 고정한다.
+- review-driven repair loop는 `GRW-15`의 latest verification report discipline과 retry/blocked semantics를 재사용한다.
+- `.github/PULL_REQUEST_TEMPLATE.md`는 이미 필요한 필드를 갖추고 있으므로, 이번 이슈에서는 template 구조를 바꾸지 않는다.
+
+## Verification
+
+- `sed -n '1,320p' docs/operations/dual-agent-review-policy.md`
+  - 결과: review invariants, 역할 분리, `Reviewer Minimum Context`, verdict semantics, review repair loop, evidence rule, draft checklist가 한 문서에 정리된 것을 확인했다.
+- `rg -n "dual-agent|review verdict|review evidence|self-approval|Reviewer Minimum Context|repair loop|Independent Review" docs/operations/dual-agent-review-policy.md docs/architecture/harness-system-map.md docs/operations/workflow-governance.md docs/operations/verification-contract-registry.md docs/operations/README.md docs/product/harness-roadmap.md .github/PULL_REQUEST_TEMPLATE.md`
+  - 결과: 새 review policy의 핵심 용어와 architecture/operations/product/template hook이 함께 grep되는 것을 확인했다.
+- sample reviewer handoff와 verdict 흐름 수동 검토
+  - 결과: reviewer가 exec plan, latest verification report, diff summary, remaining risks만으로 `approved`, `changes-requested`, `blocked` 분기 조건을 판별할 수 있음을 확인했다.
+- `git diff --check`
+  - 결과: whitespace 또는 patch formatting 오류가 없음을 확인했다.
+- GitHub Issue `#41` body render 확인
+  - 결과: issue 본문이 섹션과 줄바꿈을 유지한 채 생성된 것을 확인했다.
+
+## Evidence
+
+문서 작업이므로 브라우저, 로그, 메트릭 artifact는 필수는 아니다. 대신 아래를 근거로 남긴다.
+
+- dual-agent review policy 본문
+- reviewer minimum context와 verdict rule
+- review evidence 규칙과 draft checklist
+- architecture/operations/product 연결 결과
+- GitHub Issue `#41` body 검증 결과
+
+## Risks or Blockers
+
+- review verdict를 너무 세분화하면 PR template과 후속 skill의 재사용성이 떨어질 수 있으므로, 이번 작업은 상태 머신과 직접 연결되는 최소 vocabulary만 유지해야 한다.
+- verification registry와 review policy가 서로 다른 retry semantics를 가지면 repair loop가 흔들릴 수 있으므로, review-driven repair는 `GRW-15`와 충돌 없이 연결되어야 한다.
+
+## Next Preconditions
+
+- `GRW-17`: failure-to-guardrail feedback loop 정의
+- `GRW-18`: workflow repo pilot issue로 새 흐름 1회 검증
+- `GRW-S08`: verification/review-loop skill pack
+
+## Docs Updated
+
+- `docs/operations/dual-agent-review-policy.md`
+- `docs/operations/README.md`
+- `docs/operations/workflow-governance.md`
+- `docs/operations/verification-contract-registry.md`
+- `docs/architecture/harness-system-map.md`
+- `docs/product/harness-roadmap.md`
+- `docs/exec-plans/completed/2026-04-07-grw-16-dual-agent-review-policy.md`
+
+## Skill Consideration
+
+이번 작업은 skill을 직접 작성하는 단계는 아니다. 대신 후속 `reviewer-handoff`, `repair-loop-triage`, `verification-contract-runner`가 그대로 재사용할 수 있도록 reviewer minimum context, verdict vocabulary, review evidence rule을 source of truth로 먼저 고정한다.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -8,6 +8,7 @@
 - [request-routing-policy.md](request-routing-policy.md)
 - [tool-boundary-matrix.md](tool-boundary-matrix.md)
 - [verification-contract-registry.md](verification-contract-registry.md)
+- [dual-agent-review-policy.md](dual-agent-review-policy.md)
 - [workflow-verification-runtime.md](workflow-verification-runtime.md)
 - [manual-refresh-flow.md](manual-refresh-flow.md)
 - [daily-batch-flow.md](daily-batch-flow.md)

--- a/docs/operations/dual-agent-review-policy.md
+++ b/docs/operations/dual-agent-review-policy.md
@@ -111,6 +111,7 @@ review verdict는 PR 본문, review comment, exec plan close-out 중 최소 한 
   - Exec plan: `docs/exec-plans/...`
   - Latest verification report: `passed`
   - Diff summary: `<summary>`
+  - Source-of-truth update: `<updated docs or why not needed>`
   - Remaining risks / skipped checks: `<summary>`
 - Review Verdict: `approved | changes-requested | blocked`
 - Findings / Change Requests:
@@ -122,7 +123,7 @@ review verdict는 PR 본문, review comment, exec plan close-out 중 최소 한 
 필수 규칙:
 
 - `Implementer`, `Reviewer`, `Review Verdict`는 항상 적는다.
-- `Reviewer Input`에는 최소 컨텍스트 네 가지가 요약돼야 한다.
+- `Reviewer Input`에는 최소 컨텍스트 다섯 가지가 요약돼야 한다.
 - `approved`면 blocking finding이 없다는 점이 드러나야 한다.
 - `changes-requested`면 어떤 수정이 필요한지와 re-run 대상이 드러나야 한다.
 - 문서 전용 issue라도 review evidence를 생략하지 않는다. artifact가 없을 뿐, verdict 근거는 남겨야 한다.

--- a/docs/operations/dual-agent-review-policy.md
+++ b/docs/operations/dual-agent-review-policy.md
@@ -1,0 +1,143 @@
+# Dual-Agent Review Policy
+
+이 문서는 [../architecture/harness-system-map.md](../architecture/harness-system-map.md)의 `Reviewing`, `Repairing`, `Feedback Pending` semantics를 실제 운영 규칙으로 고정한다. [verification-contract-registry.md](verification-contract-registry.md)가 reviewer handoff 전의 verification 완료 조건을 잠근다면, 이 문서는 reviewer가 어떤 입력을 읽고 어떤 verdict를 남기며 어떤 경우에 repair 또는 `Blocked`로 되돌리는지를 잠근다.
+
+관련 운영 규칙은 [workflow-governance.md](workflow-governance.md), verification handoff minimum은 [verification-contract-registry.md](verification-contract-registry.md)를 따른다.
+
+## Policy Invariants
+
+- implementer와 reviewer는 반드시 서로 다른 agent 또는 사람이어야 한다.
+- review는 latest verification report의 overall status가 `passed`이고 reviewer handoff minimum이 채워진 뒤에만 시작할 수 있다.
+- reviewer는 diff만 보지 않고 exec plan, latest verification report, 남은 리스크를 함께 읽어야 한다.
+- reviewer는 현재 issue의 scope, write scope, verification contract, source of truth를 기준으로 판단한다. 새 목표 추가나 범위 확장은 review 단계에서 승인하지 않는다.
+- review evidence는 필수 산출물이다. verdict만 있고 reviewer input이나 finding 근거가 없으면 `Completed` 판정으로 보지 않는다.
+- future skill, template, checklist는 이 문서를 압축해서 재사용할 수 있지만, 이 문서를 대체하거나 override할 수는 없다.
+
+## Role Split
+
+| Role | Must Do | Must Not Do | Required Output |
+| --- | --- | --- | --- |
+| Implementer | exec plan 범위 안에서 변경을 만들고 latest verification report를 준비한다. reviewer에게 diff summary, touched doc, 남은 리스크, conditional command 생략 사유를 넘긴다. review finding이 blocking이면 수정 후 관련 명령을 다시 실행한다. | 자기 결과를 최종 승인하지 않는다. review 전에 verification report 없이 완료를 주장하지 않는다. blocking finding을 non-blocking note로 축소하지 않는다. | diff, latest verification report, reviewer handoff input |
+| Reviewer | implementer와 분리된 관점으로 scope, verification, diff, source-of-truth update, residual risk를 검토한다. finding을 blocking과 non-blocking으로 구분하고 verdict를 남긴다. | implementer 역할까지 겸해 자기 손으로 수정하며 review를 종료하지 않는다. verification이 비어 있는데 승인하지 않는다. 범위 밖 작업을 구두로 끼워 넣지 않는다. | review verdict, findings, review evidence |
+
+## Reviewer Minimum Context
+
+reviewer는 최소한 아래 입력을 받아야 한다.
+
+- exec plan 경로와 linked issue 또는 PR
+- latest verification report
+- touched diff summary와 touched file 또는 doc 목록
+- source-of-truth update 목록 또는 "업데이트 불필요" 사유
+- 남은 리스크, skipped conditional command, follow-up 필요 사항
+
+선택 입력:
+
+- screenshot, trace, video, log 요약, metric evidence
+- 이전 repair attempt 요약
+- 관련 review comment thread 링크
+
+reviewer는 아래 중 하나라도 있으면 verdict를 `blocked`로 둔다.
+
+- latest verification report가 없거나 latest가 아니다
+- latest verification report의 overall status가 `passed`가 아니다
+- exec plan이나 write scope를 확인할 수 없다
+- diff summary와 실제 변경 범위가 맞지 않아 검토 기준을 고정할 수 없다
+- canonical source가 없어 reviewer가 새 정책을 발명해야만 verdict를 낼 수 있다
+
+## Review Read Order
+
+1. exec plan에서 문제 정의, scope, non-scope, write scope, verification contract를 확인한다.
+2. latest verification report에서 required command 결과와 skipped 이유를 확인한다.
+3. diff와 touched source-of-truth를 읽고 실제 변경이 issue 목표와 일치하는지 본다.
+4. 남은 리스크와 follow-up을 읽고 이번 issue 안에서 닫히는지, 다음 issue로 넘겨야 하는지를 판단한다.
+
+이 순서를 건너뛰어도 되는 경우는 없다. reviewer는 최소 컨텍스트를 읽기 전에 verdict를 먼저 선언하지 않는다.
+
+## Verdict Vocabulary
+
+| Verdict | Meaning | Required Consequence |
+| --- | --- | --- |
+| `approved` | implementer/reviewer 분리가 지켜졌고 latest verification report, diff, source-of-truth update, 남은 리스크를 검토한 결과 blocking finding이 없다 | `Feedback Pending`으로 진행한다 |
+| `changes-requested` | 현재 issue 범위 안에서 수리 가능한 blocking finding이 하나 이상 있다 | `Repairing`으로 되돌린다 |
+| `blocked` | 별도 reviewer 부재, missing canonical source, missing review input, boundary conflict처럼 현재 issue 안에서 review를 닫을 수 없다 | `Blocked` 또는 follow-up planning으로 전환한다 |
+
+추가 규칙:
+
+- non-blocking note는 `approved`와 함께 남길 수 있다.
+- implementer와 reviewer가 동일하면 기본 verdict는 `changes-requested`다. 별도 reviewer를 배정할 수 없는 상황까지 확인되면 `blocked`로 올린다.
+- reviewer는 `approved`를 주면서 blocking finding을 함께 남기지 않는다.
+
+## Finding Classification
+
+### Blocking Finding
+
+아래 중 하나라도 해당하면 `changes-requested` 또는 `blocked` 사유가 된다.
+
+- issue scope 또는 write scope를 벗어난 변경
+- verification report 누락, stale report, diff와 report 불일치
+- required command 재실행이 필요한데 latest report가 갱신되지 않음
+- source-of-truth update가 필요하지만 빠져 있음
+- correctness, regression, contract, security, reliability에 직접 영향을 주는 문제
+- reviewer separation invariant 위반
+
+### Non-Blocking Note
+
+아래는 기본적으로 approval을 막지 않는다.
+
+- naming, wording, comment 정리
+- 후속 issue로 넘겨도 되는 guardrail 후보
+- 현재 목표와 무관한 선택적 refactor 제안
+
+non-blocking note도 기록은 남겨야 하지만, implementer가 같은 턴에서 반드시 해결해야 하는 의무로 바꾸지 않는다.
+
+## Review Repair Loop
+
+- `changes-requested` verdict에는 최소한 blocking finding, 기대 next action, 다시 확인할 command 또는 문서가 들어가야 한다.
+- implementer는 blocking finding을 줄이는 실제 수정 하나 이상을 남기고, 영향을 받은 required command를 다시 실행한 뒤 latest verification report를 갱신한다.
+- baseline command가 영향을 받았으면 conditional command 성공을 유지로 간주하지 않는다. latest report에 다시 적어야 한다.
+- reviewer는 stale finding 대신 latest report와 현재 diff를 기준으로 다시 판단한다.
+- 같은 root cause가 두 번의 repair 뒤에도 남아 있으면 더 길게 밀어붙이지 말고 `blocked` 또는 follow-up issue split으로 전환한다.
+- review 단계에서 새 범위가 드러나면 기존 issue에 끼워 넣지 않고 exec plan 갱신 또는 새 issue 분해로 되돌린다.
+
+## Review Evidence Rule
+
+review verdict는 PR 본문, review comment, exec plan close-out 중 최소 한 곳에 아래 필드를 남긴다.
+
+```md
+## Independent Review
+- Implementer: `agent-or-name`
+- Reviewer: `agent-or-name`
+- Reviewer Input:
+  - Exec plan: `docs/exec-plans/...`
+  - Latest verification report: `passed`
+  - Diff summary: `<summary>`
+  - Remaining risks / skipped checks: `<summary>`
+- Review Verdict: `approved | changes-requested | blocked`
+- Findings / Change Requests:
+  - `<blocking finding or no-blocking-notes>`
+- Evidence:
+  - `<why this verdict is justified>`
+```
+
+필수 규칙:
+
+- `Implementer`, `Reviewer`, `Review Verdict`는 항상 적는다.
+- `Reviewer Input`에는 최소 컨텍스트 네 가지가 요약돼야 한다.
+- `approved`면 blocking finding이 없다는 점이 드러나야 한다.
+- `changes-requested`면 어떤 수정이 필요한지와 re-run 대상이 드러나야 한다.
+- 문서 전용 issue라도 review evidence를 생략하지 않는다. artifact가 없을 뿐, verdict 근거는 남겨야 한다.
+
+## Draft Checklist
+
+- implementer와 reviewer가 분리돼 있는가
+- exec plan의 scope, non-scope, write scope가 현재 diff와 일치하는가
+- latest verification report가 존재하고 overall status가 `passed`인가
+- skipped conditional command와 remaining risk가 reviewer input에 기록돼 있는가
+- diff와 verification report, source-of-truth update가 서로 모순되지 않는가
+- blocking finding과 non-blocking note가 명확히 구분돼 있는가
+- verdict와 next action이 state machine의 `Feedback Pending`, `Repairing`, `Blocked` 중 하나로 자연스럽게 이어지는가
+
+## Relationship To Skills
+
+- future `reviewer-handoff` skill은 이 문서의 `Reviewer Minimum Context`, `Review Read Order`, `Review Evidence Rule`을 얇게 재사용한다.
+- template와 checklist는 future skill 폴더 안에 둘 수 있지만, verdict vocabulary와 blocking 기준은 계속 이 문서가 canonical source다.

--- a/docs/operations/verification-contract-registry.md
+++ b/docs/operations/verification-contract-registry.md
@@ -291,6 +291,7 @@ reviewer에게 넘길 때는 최소한 아래 입력이 함께 있어야 한다.
 - exec plan 경로
 - latest verification report
 - touched diff 요약
+- source-of-truth update 목록 또는 업데이트 불필요 사유
 - 남은 리스크 또는 conditional command 생략 사유
 
 이 입력은 [dual-agent-review-policy.md](dual-agent-review-policy.md)의 `Reviewer Minimum Context`와 동일한 handoff surface다.

--- a/docs/operations/verification-contract-registry.md
+++ b/docs/operations/verification-contract-registry.md
@@ -2,7 +2,7 @@
 
 이 문서는 [../architecture/harness-system-map.md](../architecture/harness-system-map.md)의 `Verifying`, `Repairing`, `Blocked` semantics를 실제 실행 규약으로 고정한다. [tool-boundary-matrix.md](tool-boundary-matrix.md)가 "어떤 도구를 어디까지 쓸 수 있는가"를 잠근다면, 이 문서는 "무슨 명령을 어떤 증거와 함께 통과해야 다음 상태로 갈 수 있는가"를 잠근다.
 
-관련 운영 규칙은 [workflow-governance.md](workflow-governance.md), workflow runtime 기준은 [workflow-verification-runtime.md](workflow-verification-runtime.md)를 따른다.
+관련 운영 규칙은 [workflow-governance.md](workflow-governance.md), workflow runtime 기준은 [workflow-verification-runtime.md](workflow-verification-runtime.md), review verdict 규칙은 [dual-agent-review-policy.md](dual-agent-review-policy.md)를 따른다.
 
 ## Registry Invariants
 
@@ -292,5 +292,7 @@ reviewer에게 넘길 때는 최소한 아래 입력이 함께 있어야 한다.
 - latest verification report
 - touched diff 요약
 - 남은 리스크 또는 conditional command 생략 사유
+
+이 입력은 [dual-agent-review-policy.md](dual-agent-review-policy.md)의 `Reviewer Minimum Context`와 동일한 handoff surface다.
 
 이 입력이 비어 있으면 review 단계로 넘어간 것으로 보지 않는다.

--- a/docs/operations/workflow-governance.md
+++ b/docs/operations/workflow-governance.md
@@ -78,6 +78,7 @@
 
 - 명령 실행 결과 요약 또는 artifact 위치
 - verification report 최소 필드: contract profile, command별 status, 핵심 evidence, failure summary, next action
+- review evidence 최소 필드: implementer, reviewer, reviewer input, verdict, blocking finding 또는 no-blocking note
 - 브라우저 증거: screenshot, trace, video
 - 로그 증거: LogQL 결과 또는 로그 요약
 - 메트릭 증거: PromQL 결과 또는 지표 캡처
@@ -106,6 +107,7 @@
 - workflow 저장소 PR 본문은 `.github/PULL_REQUEST_TEMPLATE.md`를 복사한 임시 파일을 기준으로 채운다.
 - PR의 `6) Verification Contract`는 카테고리별 section 아래에 check별 block 형식으로 작성한다.
 - 성공한 검증은 최종 상태와 핵심 evidence만 짧게 적고, 실패, 재시도, 예외만 상세히 남긴다.
+- PR의 `7) Independent Review`는 [dual-agent-review-policy.md](dual-agent-review-policy.md)의 reviewer minimum context와 verdict vocabulary를 따른다.
 - 생성 직후에는 `gh issue view --json body` 또는 `gh pr view --json body`로 본문이 예상한 줄바꿈과 섹션을 유지하는지 확인한다.
 - Issue template은 최소한 `문제`, `왜 지금`, `범위/비범위`, `write scope`, `context source`, `verification plan`, `open questions`를 포함해야 한다.
 - PR template은 최소한 `연결된 issue`, `범위/비범위`, `write scope`, `verification 결과`, `독립 review 결과`, `feedback follow-up`, `문서 반영`, `리스크`를 포함해야 한다.
@@ -145,6 +147,7 @@
 - 허용된 write scope 밖의 파일은 수정하지 않는다.
 - network나 escalation이 필요하면 목적과 범위를 exec plan 또는 최종 close-out에 남긴다.
 - verification failure가 나면 registry의 retry budget 안에서만 repair loop를 돌리고, budget 초과나 missing canonical source는 `Blocked` 또는 후속 planning으로 넘긴다.
+- review 단계에 들어가기 전 latest verification report와 reviewer minimum context를 준비한다.
 - source of truth 문서를 함께 업데이트하거나, 업데이트가 불필요한 이유를 남긴다.
 - 검증 명령과 최종 상태를 반드시 남기고, 실패나 예외가 있었다면 요약을 남긴다.
 - 새로 생긴 반복 절차가 있다면 skill 후보로 제안하되, 이번 Issue 범위를 넘는 구현은 하지 않는다.

--- a/docs/product/harness-roadmap.md
+++ b/docs/product/harness-roadmap.md
@@ -30,7 +30,7 @@
 4. task type에 맞는 context pack만 Agent에 제공한다.
 5. Implementer Agent는 허용된 도구 경계 안에서만 작업한다.
 6. verification contract registry에 정의된 명령이 통과해야 다음 단계로 넘어간다.
-7. Reviewer Agent는 구현 diff와 검증 결과를 검토하고, 통과 또는 수정 요청을 결정한다.
+7. Reviewer Agent는 [../operations/dual-agent-review-policy.md](../operations/dual-agent-review-policy.md)에 따라 구현 diff와 검증 결과를 검토하고, 통과 또는 수정 요청을 결정한다.
 8. 실패한 작업은 feedback ledger에 남기고 다음 가드레일 후보로 전환한다.
 
 ## 권장 실행 순서


### PR DESCRIPTION
## 1) Summary
- `docs/operations/dual-agent-review-policy.md`를 추가해 implementer/reviewer 역할 분리, reviewer minimum context, verdict vocabulary, review evidence rule을 canonical source로 고정했습니다.
- verification registry, governance, system map, roadmap, operations index, GRW-16 exec plan을 새 review policy에 맞춰 연결했습니다.

## 2) Linked Issue
- Closes #41
- Issue ID: `GRW-16`
- 대상 저장소: `git-ranker-workflow`

## 3) Harness Contract
- Request Type: `review-policy`
- Context / Source of Truth:
  - `AGENTS.md`
  - `PLANS.md`
  - `docs/operations/workflow-governance.md`
  - `docs/architecture/harness-system-map.md`
  - `docs/operations/verification-contract-registry.md`
  - `docs/product/harness-roadmap.md`
  - `docs/exec-plans/completed/2026-04-07-grw-15-verification-contract-registry-repair-loop-policy.md`
- Write Scope:
  - `docs/operations/`
  - `docs/architecture/`
  - `docs/product/`
  - `docs/exec-plans/`
- Branch / Exec Plan:
  - `feat/grw-16-dual-agent-review-policy`
  - `docs/exec-plans/completed/2026-04-07-grw-16-dual-agent-review-policy.md`

## 4) Scope
- In Scope:
  - dual-agent review policy 문서 추가
  - reviewer handoff minimum, verdict semantics, review evidence rule 정의
  - architecture/operations/product hook 연결
- Out of Scope:
  - `GRW-S08` skill pack 작성
  - backend/frontend 앱 코드 변경
  - PR review bot 또는 runtime 자동화 구현

## 5) Outputs
- 변경된 문서 / 파일 / 디렉터리:
  - `docs/operations/dual-agent-review-policy.md`
  - `docs/operations/verification-contract-registry.md`
  - `docs/operations/workflow-governance.md`
  - `docs/operations/README.md`
  - `docs/architecture/harness-system-map.md`
  - `docs/product/harness-roadmap.md`
  - `docs/exec-plans/completed/2026-04-07-grw-16-dual-agent-review-policy.md`
- 후속 작업이 바로 참조할 산출물:
  - reviewer minimum context
  - `approved | changes-requested | blocked` verdict vocabulary
  - review evidence rule

## 6) Verification Contract

### Docs / Policy

#### Check Item
- Name: dual-agent review policy 본문 검토
- Command / Check: `sed -n '1,320p' docs/operations/dual-agent-review-policy.md`
- Final Status: `PASS`
- Evidence: review invariants, role split, reviewer minimum context, verdict semantics, repair loop, evidence rule, draft checklist가 한 문서에 정리된 것을 확인
- Failure / Exception:

#### Check Item
- Name: review policy hook grep 확인
- Command / Check: `rg -n "dual-agent|review verdict|review evidence|self-approval|Reviewer Minimum Context|repair loop|Independent Review" docs/operations/dual-agent-review-policy.md docs/architecture/harness-system-map.md docs/operations/workflow-governance.md docs/operations/verification-contract-registry.md docs/operations/README.md docs/product/harness-roadmap.md .github/PULL_REQUEST_TEMPLATE.md`
- Final Status: `PASS`
- Evidence: review policy 핵심 용어와 architecture/operations/product/template hook이 함께 grep되는 것을 확인
- Failure / Exception:

### Type / Lint / Test / Build

#### Check Item
- Name: 해당 없음
- Command / Check: 문서 전용 작업
- Final Status: `N/A`
- Evidence: runtime/code build 변경 없음
- Failure / Exception:

### Manual Check

#### Check Item
- Name: sample reviewer handoff 흐름 검토
- Command / Check: sample reviewer handoff와 verdict 흐름 수동 검토
- Final Status: `PASS`
- Evidence: reviewer가 exec plan, latest verification report, diff summary, remaining risks만으로 `approved`, `changes-requested`, `blocked` 분기 조건을 판별할 수 있음을 확인
- Failure / Exception:

### Other Task-Specific Contract

#### Check Item
- Name: patch formatting 확인
- Command / Check: `git diff --check`
- Final Status: `PASS`
- Evidence: whitespace 또는 patch formatting 오류 없음
- Failure / Exception:

#### Check Item
- Name: issue body render 확인
- Command / Check: `gh issue view --repo alexization/git-ranker-workflow 41 --json body`
- Final Status: `PASS`
- Evidence: issue 본문이 섹션과 줄바꿈을 유지한 채 생성된 것을 확인
- Failure / Exception: `gh auth status`의 기본 토큰은 invalid였지만 issue view 명령은 현재 환경에서 정상 응답

## 7) Independent Review
- Implementer: `Codex`
- Reviewer: `Pending separate reviewer`
- Reviewer Input:
  - Exec plan: `docs/exec-plans/completed/2026-04-07-grw-16-dual-agent-review-policy.md`
  - Latest verification report: docs verification complete
  - Diff summary: dual-agent review policy 문서 추가와 관련 hook 연결
  - Source-of-truth update: `docs/operations/dual-agent-review-policy.md`, `docs/operations/verification-contract-registry.md`, `docs/operations/workflow-governance.md`, `docs/operations/README.md`, `docs/architecture/harness-system-map.md`, `docs/product/harness-roadmap.md`, `docs/exec-plans/completed/2026-04-07-grw-16-dual-agent-review-policy.md`
  - Remaining risks / skipped checks: 독립 reviewer verdict 미기록
- Review Verdict: `blocked`
- Findings / Change Requests:
  - open PR 상태이지만 별도 reviewer의 `approved | changes-requested | blocked` verdict가 아직 없음
  - implementer와 reviewer 분리가 충족되기 전까지 final review evidence는 미완료 상태

## 8) Source of Truth Update
- 업데이트한 문서:
  - `docs/operations/dual-agent-review-policy.md`
  - `docs/operations/verification-contract-registry.md`
  - `docs/operations/workflow-governance.md`
  - `docs/operations/README.md`
  - `docs/architecture/harness-system-map.md`
  - `docs/product/harness-roadmap.md`
  - `docs/exec-plans/completed/2026-04-07-grw-16-dual-agent-review-policy.md`
- 업데이트하지 않은 문서와 사유:
  - `.github/PULL_REQUEST_TEMPLATE.md`: 기존 구조가 이미 reviewer minimum context와 독립 review 섹션을 수용하므로 구조 변경 불필요

## 9) Feedback / Guardrail Follow-up
- 이번 작업에서 실제로 발생한 실패 / 예외 / 취약 지점:
  - `gh auth status`의 기본 토큰이 invalid 상태였음
- 새 guardrail 후보:
  - 없음. 이번 이슈의 정책 범위 내에서는 source of truth 정렬로 닫힘
- 후속 Issue 또는 TODO:
  - `GRW-S08`에서 `reviewer-handoff` skill, templates, checklists를 이 policy 기준으로 구현

## 10) Risks and Rollback
- Risks:
  - open PR 상태이지만 독립 reviewer verdict가 추가되기 전까지 `Completed` close-out의 최종 운영 증거는 GitHub PR 상에서 아직 완결되지 않음
- Rollback Plan:
  - `docs/operations/dual-agent-review-policy.md`와 관련 hook 문서를 revert하면 이전 review semantics로 되돌릴 수 있음

## 11) Checklist
- [x] 연결된 Issue가 있다
- [x] Scope / Out of Scope가 적혀 있다
- [x] Write Scope가 적혀 있다
- [x] Verification 최종 상태와 예외가 기입되어 있다
- [ ] Implementer와 Reviewer가 분리되어 있다
- [x] Source of Truth 반영 여부가 적혀 있다
- [x] Feedback 또는 후속 guardrail 후보가 적혀 있다
