### PR TITLE
[GRW-17] failure-to-guardrail feedback loop 정의

### DIFF
--- a/docs/architecture/harness-system-map.md
+++ b/docs/architecture/harness-system-map.md
@@ -122,4 +122,4 @@
 - [../operations/tool-boundary-matrix.md](../operations/tool-boundary-matrix.md)는 `Context Ready`와 `Implementing` 단계의 허용 도구와 write scope 경계를 상세화한다.
 - [../operations/verification-contract-registry.md](../operations/verification-contract-registry.md)는 `Verifying`, `Repairing`, `Blocked` semantics와 retry budget을 명시한다.
 - [../operations/dual-agent-review-policy.md](../operations/dual-agent-review-policy.md)는 `Reviewing` 단계의 reviewer input, verdict, repair loop, evidence rule을 구체화한다.
-- feedback ledger/policy는 `Feedback Pending`과 guardrail 승격 규칙을 고정한다.
+- [../operations/failure-to-guardrail-feedback-loop.md](../operations/failure-to-guardrail-feedback-loop.md)는 `Feedback Pending` close-out, feedback ledger, guardrail 승격 규칙을 고정한다.

--- a/docs/exec-plans/active/2026-04-07-grw-17-failure-to-guardrail-feedback-loop.md
+++ b/docs/exec-plans/active/2026-04-07-grw-17-failure-to-guardrail-feedback-loop.md
@@ -1,0 +1,134 @@
+# 2026-04-07-grw-17-failure-to-guardrail-feedback-loop
+
+- Issue ID: `GRW-17`
+- GitHub Issue: `#43`
+- Status: `In Progress`
+- Repository: `git-ranker-workflow`
+- Branch Name: `feat/grw-17-failure-to-guardrail-feedback-loop`
+- Task Slug: `2026-04-07-grw-17-failure-to-guardrail-feedback-loop`
+
+## Problem
+
+`Feedback Pending` 상태와 "실패를 guardrail 후보로 승격한다"는 상위 원칙은 이미 source of truth에 있다. 하지만 실제 작업에서 어떤 failure taxonomy를 써야 하는지, 어떤 입력을 feedback ledger에 남겨야 하는지, 어떤 경우에 `문서 규칙`, `skill`, `테스트`, `CI`, `template` 중 하나로 승격해야 하는지, 언제 `no new guardrail`로 닫아도 되는지는 아직 canonical policy로 잠겨 있지 않다.
+
+이 공백이 남아 있으면 verification failure와 review finding이 close-out마다 다른 형식으로 남고, 같은 종류의 실패가 반복돼도 어떤 guardrail을 추가해야 하는지 일관되게 판단할 수 없다. 후속 `guardrail-hardening` skill pack과 pilot issue가 재사용할 feedback loop를 먼저 고정해야 한다.
+
+## Why Now
+
+`GRW-15`와 `GRW-16`까지 완료되면서 verification과 review 단계의 입력과 verdict는 잠겼다. 이제 `Feedback Pending -> Completed` 구간의 close-out 기준을 정리해야 하네스의 happy path와 repair path가 모두 닫힌다.
+
+또한 같은 failure class가 반복될 때 문서, skill, 테스트, CI, template 중 어디로 승격할지를 결정론적으로 남겨야 `GRW-S09`와 `GRW-18`이 공통 입력을 사용할 수 있다.
+
+## Scope
+
+- `docs/operations/`에 failure-to-guardrail feedback loop source of truth를 추가한다.
+- failure taxonomy, feedback ledger field, 승격 대상, `no new guardrail` 기준을 정의한다.
+- `Feedback Pending -> Completed` 단계에서 필요한 implementer/reviewer input과 close-out 규칙을 문서화한다.
+- guardrail ledger template를 별도 문서로 추가한다.
+- 관련 architecture/operations/product hook과 exec plan을 갱신한다.
+
+## Non-scope
+
+- 자동 PR 생성, 자동 복구, 자동 CI 생성
+- backend/frontend 앱 코드 변경
+- `GRW-S09` skill pack 구현
+- `.github/` template 구조 변경
+- sibling repo inspection을 넘어서는 cross-repo planning 확장
+
+## Write Scope
+
+- Primary repo: `git-ranker-workflow`
+- Allowed write paths:
+  - `docs/operations/`
+  - `docs/architecture/`
+  - `docs/product/` 필요 시
+  - `docs/exec-plans/`
+- Control-plane artifacts:
+  - `docs/exec-plans/active/2026-04-07-grw-17-failure-to-guardrail-feedback-loop.md`
+  - `docs/exec-plans/completed/2026-04-07-grw-17-failure-to-guardrail-feedback-loop.md`
+  - `.artifacts/2026-04-07-grw-17-failure-to-guardrail-feedback-loop/` 필요 시
+- Explicitly forbidden:
+  - sibling app repo code write
+  - `.github/` template 구조 변경
+  - scope 밖 stable source of truth mass update
+- Network / external systems:
+  - GitHub Issue body render 확인
+- Escalation triggers:
+  - 없음. 문서 작업 범위에서 처리한다.
+
+## Outputs
+
+- `docs/operations/failure-to-guardrail-feedback-loop.md`
+- `docs/operations/guardrail-ledger-template.md`
+- feedback taxonomy, promotion rule, `no new guardrail` close-out rule
+- 관련 hook 문서 갱신
+- `GRW-17` 실행 기록
+
+## Working Decisions
+
+- 이번 작업의 primary context pack은 `workflow-docs`다.
+- feedback 단계의 canonical source는 `docs/operations/failure-to-guardrail-feedback-loop.md`에 둔다.
+- guardrail ledger는 PR/exec plan close-out에서 재사용 가능한 entry template를 별도 문서로 분리한다.
+- 승격 대상은 work item catalog의 기본 결정대로 `문서 규칙`, `skill`, `테스트`, `CI`, `template` 다섯 가지로 고정한다.
+- 같은 root cause의 반복 여부와 현재 issue 내부 수리 가능성은 `GRW-15`의 repair loop semantics와 `GRW-16`의 review verdict 규칙을 재사용해 판정한다.
+- stable source of truth 문서에는 task ID를 follow-up 설명용으로 남기지 않는다.
+
+## Verification
+
+- `sed -n '1,320p' docs/operations/failure-to-guardrail-feedback-loop.md`
+  - 결과: failure taxonomy, ledger flow, 승격 규칙, `no new guardrail` 기준, close-out minimum이 한 문서에 정리된 것을 확인했다.
+- `sed -n '1,220p' docs/operations/guardrail-ledger-template.md`
+  - 결과: ledger entry 최소 필드, status vocabulary, 예시 형식이 reviewer/implementer handoff에 재사용 가능한 것을 확인했다.
+- `rg -n "feedback|guardrail|ledger|no new guardrail|failure taxonomy|Feedback Pending" docs/operations docs/architecture docs/product docs/exec-plans`
+  - 결과: 새 policy와 인접 hook이 operations/architecture/product/exec plan에서 함께 grep되는 것을 확인했다.
+- 과거 failure 사례 2~3개 수동 분류
+  - 결과: 아래 `Representative Past Failure Classification`에 기록한 세 사례 모두 taxonomy와 ledger template로 승격 대상을 분류할 수 있음을 확인했다.
+- `git diff --check`
+  - 결과: whitespace 또는 patch formatting 오류가 없음을 확인했다.
+- GitHub Issue `#43` body render 확인
+  - 결과: issue 본문이 섹션과 줄바꿈을 유지한 채 생성된 것을 확인했다.
+
+## Evidence
+
+문서 작업이므로 브라우저, 로그, 메트릭 artifact는 필수는 아니다. 대신 아래를 근거로 남긴다.
+
+- feedback loop policy 본문
+- ledger template 본문
+- 과거 failure 사례 분류 결과
+- 관련 hook 문서 갱신 결과
+- `git diff --check` 결과
+- GitHub Issue `#43` body 검증 결과
+
+## Representative Past Failure Classification
+
+| Source | Failure class | Promotion decision | Why |
+| --- | --- | --- | --- |
+| `docs/exec-plans/completed/2026-04-06-grw-19-harness-issue-pr-template-alignment.md` | `evidence-closeout` | `template` | Issue/PR close-out에서 verification, review, feedback 필드가 부족해 structured input 누락이 반복될 수 있었기 때문이다. |
+| `docs/exec-plans/completed/2026-04-07-grw-15-verification-contract-registry-repair-loop-policy.md` | `verification-contract` | `docs-rule` | 저장소별 verification entrypoint와 report shape를 잠그는 canonical registry가 없어서 completion semantics가 흔들렸기 때문이다. |
+| `docs/exec-plans/completed/2026-04-07-grw-16-dual-agent-review-policy.md` | `review-handoff` | `docs-rule` | implementer/reviewer 분리, reviewer input, verdict 기준 자체가 source of truth로 고정되지 않아 self-approval과 review drift 위험이 있었기 때문이다. |
+
+## Risks or Blockers
+
+- failure taxonomy를 너무 세분화하면 implementer/reviewer가 실제 close-out에서 일관되게 적용하기 어려워질 수 있다.
+- 승격 규칙이 review/verification retry semantics와 충돌하면 같은 failure가 repair 대상인지, follow-up guardrail 대상인지 구분이 흐려질 수 있다.
+- template와 skill을 지금 같이 구현하면 `GRW-S09` 범위를 잠식하므로, 이번 작업은 policy와 ledger template까지만 잠근다.
+- 독립 reviewer가 아직 배정되지 않았으므로 `Completed` close-out과 review evidence는 후속 review handoff에서 채워야 한다.
+
+## Next Preconditions
+
+- `GRW-S09`: guardrail-hardening skill pack
+- `GRW-18`: workflow repo pilot issue로 새 흐름 1회 검증
+
+## Docs Updated
+
+- `docs/operations/failure-to-guardrail-feedback-loop.md`
+- `docs/operations/guardrail-ledger-template.md`
+- `docs/operations/README.md`
+- `docs/operations/workflow-governance.md`
+- `docs/architecture/harness-system-map.md`
+- `docs/product/harness-roadmap.md`
+- `docs/exec-plans/active/2026-04-07-grw-17-failure-to-guardrail-feedback-loop.md`
+
+## Skill Consideration
+
+이번 작업은 skill을 직접 작성하는 단계는 아니다. 대신 후속 `guardrail-ledger-update`, `failure-to-policy` skill이 그대로 재사용할 수 있도록 failure taxonomy, ledger field, 승격 규칙, `no new guardrail` close-out을 source of truth로 먼저 고정한다.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -9,6 +9,8 @@
 - [tool-boundary-matrix.md](tool-boundary-matrix.md)
 - [verification-contract-registry.md](verification-contract-registry.md)
 - [dual-agent-review-policy.md](dual-agent-review-policy.md)
+- [failure-to-guardrail-feedback-loop.md](failure-to-guardrail-feedback-loop.md)
+- [guardrail-ledger-template.md](guardrail-ledger-template.md)
 - [workflow-verification-runtime.md](workflow-verification-runtime.md)
 - [manual-refresh-flow.md](manual-refresh-flow.md)
 - [daily-batch-flow.md](daily-batch-flow.md)

--- a/docs/operations/failure-to-guardrail-feedback-loop.md
+++ b/docs/operations/failure-to-guardrail-feedback-loop.md
@@ -1,0 +1,147 @@
+# Failure-To-Guardrail Feedback Loop
+
+이 문서는 [../architecture/harness-system-map.md](../architecture/harness-system-map.md)의 `Feedback Pending`과 `Completed` semantics를 실제 close-out 규칙으로 고정한다. [verification-contract-registry.md](verification-contract-registry.md)가 verification의 pass/fail과 repair budget을 잠그고, [dual-agent-review-policy.md](dual-agent-review-policy.md)가 review verdict와 reviewer evidence를 잠근다면, 이 문서는 "이 failure를 어떤 guardrail로 승격할 것인가"와 "언제 `no new guardrail`로 닫을 수 있는가"를 잠근다.
+
+관련 운영 규칙은 [workflow-governance.md](workflow-governance.md)를 따른다.
+
+## Policy Invariants
+
+- feedback 단계는 success path와 failure path 모두에서 필요하다. `approved`로 끝난 작업도 `no new guardrail` 또는 guardrail 후보 판단을 남겨야 한다.
+- feedback close-out은 verification과 review를 대체하지 않는다. in-scope repair가 아직 남아 있으면 feedback으로 우회 종료하지 않는다.
+- ledger entry는 root cause 하나당 하나씩 남긴다. 서로 다른 failure class를 한 entry에 섞지 않는다.
+- 같은 root cause가 반복되면 다음 턴에는 guardrail 승격 여부가 반드시 결정돼야 한다.
+- 승격 대상은 `docs-rule`, `skill`, `test`, `ci`, `template`, `no-new-guardrail` 여섯 가지로 고정한다.
+- stable source of truth가 필요한 문제는 먼저 `docs-rule`을 검토한다. rule이 이미 있는데 실행 순서가 흔들리면 `skill` 또는 `template`을 본다.
+- deterministic check로 막을 수 있는 regression은 가능하면 `test` 또는 `ci`로 올린다. 단순 메모만 남기고 반복시키지 않는다.
+- `no-new-guardrail`도 빈칸이 아니라 명시적 결정이다. 왜 새 가드레일이 필요 없는지 근거를 남겨야 한다.
+
+## Feedback Entry Preconditions
+
+feedback close-out을 시작할 때 최소한 아래 입력이 있어야 한다.
+
+- exec plan
+- latest verification report 또는 `Blocked` 이유
+- latest review verdict 또는 review를 시작할 수 없었던 이유
+- repair attempt 요약 필요 시
+- 남은 리스크, skipped check, failure note
+
+추가 규칙:
+
+- `Rejected`와 `conversation-only` close-out은 feedback ledger 대상이 아니다.
+- `Blocked`로 끝난 작업도 root cause가 harness 내부 개선으로 줄일 수 있다면 ledger entry를 남긴다.
+- 현재 issue 안에서 이미 guardrail을 함께 추가했다면, 그 사실도 ledger entry에 남긴다.
+
+## Root Cause Normalization Rule
+
+feedback entry를 쓰기 전 failure를 아래 순서로 정리한다.
+
+1. 가장 최근의 verification failure, review finding, blocked reason을 모은다.
+2. 원인이 다른 항목은 분리한다.
+3. "무엇이 실패했는가"보다 "왜 같은 실수가 다시 생길 수 있는가"를 root cause로 적는다.
+4. 현재 issue 안에서 이미 해결된 구현 버그와, 다음 guardrail로 남겨야 할 시스템 문제를 구분한다.
+
+예시:
+
+- `git diff --check` 실패와 reviewer input 누락은 서로 다른 root cause이므로 entry를 나눈다.
+- 동일한 verification command를 두 번 빠뜨린 문제는 command 이름이 아니라 "verification handoff shape 미고정"으로 묶는다.
+
+## Failure Taxonomy
+
+| Failure class | Typical signal | Primary stage | Default question |
+| --- | --- | --- | --- |
+| `intake-scope` | request가 한 issue로 고정되지 않음, write scope drift, non-scope 누락 | `Routed`, `Interviewing`, `Planned` | intake rule이나 planning template가 failure를 더 일찍 막았어야 하는가 |
+| `context-boundary` | 잘못된 context pack 선택, sibling repo eager load, boundary 위반, scope 밖 수정 시도 | `Context Ready`, `Implementing` | boundary rule을 문서나 skill로 더 좁혀야 하는가 |
+| `verification-contract` | latest report 누락, command 불일치, precondition 미기록, retry budget 해석 drift | `Verifying`, `Repairing` | verification registry, runner skill, template 중 무엇이 비어 있었는가 |
+| `review-handoff` | self-approval, reviewer input 누락, diff/report mismatch, finding 분류 drift | `Reviewing` | review policy만으로 충분한가, handoff shape를 template나 skill로 더 강제해야 하는가 |
+| `behavior-regression` | correctness, contract, reliability regression이 문서 리뷰 뒤에야 발견됨 | `Implementing`, `Verifying`, `Reviewing` | deterministic test나 CI check가 있어야 했는가 |
+| `evidence-closeout` | source-of-truth update 누락, feedback section 공란, artifact/evidence 위치 불명확 | `Feedback Pending`, `Completed` | close-out template나 docs rule이 더 강해야 하는가 |
+| `external-dependency` | Docker, port, credential, remote outage, missing worktree처럼 현재 scope 밖 환경 문제가 막음 | `Planned` 이후 어느 단계든 | harness 내부 guardrail로 줄일 수 있는 부분이 있는가, 아니면 외부 조건 안내만으로 충분한가 |
+
+## Guardrail Promotion Decision
+
+### Decision Targets
+
+| Decision | Choose when | Typical output |
+| --- | --- | --- |
+| `docs-rule` | canonical rule, vocabulary, stop condition, evidence minimum이 비어 있거나 서로 충돌한다 | policy, registry, runbook, README hook |
+| `skill` | canonical rule은 있지만 같은 순서의 실행, triage, handoff가 반복적으로 흔들린다 | skill, checklist, handoff recipe |
+| `test` | product or contract regression을 저장소 안에서 결정론적으로 재현하고 막을 수 있다 | unit, integration, e2e, contract test |
+| `ci` | 로컬 deterministic check는 있는데 PR/runtime에서 일관되게 실행되지 않는다 | CI job, required check, automation gate |
+| `template` | issue, PR, exec plan, review body처럼 structured input 자체가 비어 있어 정보 누락이 반복된다 | template field, body section, form change |
+| `no-new-guardrail` | 기존 guardrail이 이미 충분하고, 이번 case가 one-off 외부 이슈이거나 현재 issue 안에서 가드레일이 이미 추가됐다 | explicit rationale only |
+
+### Selection Rules
+
+1. 같은 failure를 가장 이른 단계에서 막을 수 있는 자산을 먼저 고른다.
+2. 여러 자산이 가능하면 가장 작은 변경으로 반복을 끊는 쪽을 고른다.
+3. rule 자체가 비어 있으면 `skill`, `template`, `test`, `ci`보다 먼저 `docs-rule`을 본다.
+4. rule은 있는데 실행 순서가 빠지는 문제면 `skill` 또는 `template`을 본다.
+5. behavior regression이라면 문서 설명보다 `test`를 우선한다.
+6. local test가 이미 있는데 "실행 안 됨"이 root cause면 `ci`를 우선한다.
+7. `template`은 입력 누락 문제에만 쓴다. behavior regression이나 boundary bug를 template만으로 해결했다고 보지 않는다.
+
+## Recurrence Rule
+
+- 첫 발생이어도 blast radius가 크거나 필수 close-out field가 비어 있으면 즉시 승격할 수 있다.
+- 같은 root cause가 두 번 관측되면 `no-new-guardrail`은 예외 사유가 있어야만 가능하다.
+- 같은 root cause가 세 번 이상 반복되거나 둘 이상의 task type에 걸치면, automation이 가능한 경우 `docs-rule`만으로 닫지 않는다.
+- 현재 issue 안에서 안전하게 만들 수 없는 guardrail이면 follow-up asset 또는 issue를 남기고 `follow-up-needed`로 닫는다.
+
+## `No New Guardrail` Criteria
+
+아래 중 하나면 `no-new-guardrail`을 선택할 수 있다.
+
+- 기존 policy, template, test, CI가 이미 있었고 이번 failure는 단순 미준수이지만, 현재 issue에서 그 미준수를 다시 막는 추가 guardrail이 합리적으로 늘지 않는다.
+- 외부 서비스 장애, credential 부재, worktree 부재처럼 현재 control plane이 직접 줄일 수 없는 one-off blocker다.
+- 현재 issue diff 안에서 필요한 guardrail이 이미 추가됐다.
+- editorial wording, non-blocking note처럼 반복 방지용 시스템 자산까지 만들 가치가 없다.
+
+아래 중 하나면 `no-new-guardrail`로 닫지 않는다.
+
+- 필수 field 누락, self-approval, verification report 누락처럼 하네스 기본 통제력을 깨는 문제
+- 같은 root cause가 두 번 이상 반복된 경우
+- local deterministic check를 추가할 수 있는데 계속 문서 메모로만 넘기는 경우
+
+## Feedback Ledger Flow
+
+1. latest verification report와 review verdict를 기준으로 현재 issue의 최종 상태를 고정한다.
+2. guardrail 후보가 되는 root cause를 하나씩 분리한다.
+3. `Failure Taxonomy`에서 class를 고른다.
+4. 기존 guardrail이 이미 있는지와 recurrence를 확인한다.
+5. `Guardrail Promotion Decision`으로 승격 대상 또는 `no-new-guardrail`을 고른다.
+6. ledger entry에 follow-up asset, issue, 현재 issue 적용 여부를 남긴다.
+7. PR 본문 또는 exec plan close-out에 이번 판단을 요약한다.
+
+추가 규칙:
+
+- feedback entry는 "누가 무엇을 다음에 해야 하는가"까지 남겨야 한다.
+- 후속 작업이 필요하면 asset 이름, 문서 경로, issue 후보 중 최소 하나를 적는다.
+- 한 작업에 entry가 여러 개일 수 있다. 그러나 같은 entry가 여러 root cause를 대신하지는 않는다.
+
+## Feedback Close-Out Minimum
+
+`Feedback Pending`을 `Completed`로 넘길 때는 PR 본문, review comment, exec plan close-out 중 최소 한 곳에 아래가 있어야 한다.
+
+- latest verification 상태 또는 `Blocked` 이유
+- latest review verdict 또는 review 불가 사유
+- ledger entry 하나 이상 또는 `no new guardrail` entry
+- promotion decision 근거
+- follow-up asset, issue, 또는 "없음" 사유
+
+`Feedback / Guardrail Follow-up` 섹션이 비어 있으면 완료로 보지 않는다.
+
+## Representative Classification
+
+| Scenario | Failure class | Promotion decision | Why |
+| --- | --- | --- | --- |
+| reviewer가 exec plan과 verification report 없이 verdict를 남기려 했다 | `review-handoff` | `template` 또는 `skill` | structured input이나 handoff 절차를 더 강제해야 한다 |
+| regression이 manual review에서만 반복 발견되고 repo 안 deterministic check가 없다 | `behavior-regression` | `test` | 다음부터 같은 bug를 자동으로 막아야 한다 |
+| local test는 있지만 PR마다 빠져서 뒤늦게 깨진다 | `verification-contract` | `ci` | 실행 누락이 root cause이므로 중앙 enforcement가 필요하다 |
+| 외부 GitHub outage 때문에 read-only metadata 확인이 잠시 막혔다 | `external-dependency` | `no-new-guardrail` | harness 내부 자산을 늘려도 예방 효과가 작다 |
+
+## Relationship To Other Policies
+
+- verification 재시도, budget, `Blocked` 전환은 계속 [verification-contract-registry.md](verification-contract-registry.md)가 canonical source다.
+- reviewer verdict vocabulary와 blocking finding 기준은 계속 [dual-agent-review-policy.md](dual-agent-review-policy.md)가 canonical source다.
+- 이 문서는 verification과 review의 최신 결과가 나온 뒤, 그 결과를 다음 guardrail 자산으로 연결하는 close-out 규칙만 맡는다.
+- 후속 skill pack과 template는 이 문서를 압축해 재사용할 수 있지만, 승격 대상 vocabulary와 `no-new-guardrail` 기준은 계속 이 문서가 canonical source다.

--- a/docs/operations/guardrail-ledger-template.md
+++ b/docs/operations/guardrail-ledger-template.md
@@ -1,0 +1,68 @@
+# Guardrail Ledger Template
+
+이 문서는 [failure-to-guardrail-feedback-loop.md](failure-to-guardrail-feedback-loop.md)의 canonical ledger entry 형식을 제공한다. PR 본문, exec plan close-out, `.artifacts/` summary 어디에 남기든 아래 최소 필드는 유지한다.
+
+## Entry Template
+
+```md
+## Guardrail Ledger Entry
+- Date:
+- Task / Exec Plan:
+- Stage:
+  - `Interviewing | Planned | Context Ready | Implementing | Verifying | Reviewing | Feedback Pending | Blocked`
+- Failure class:
+  - `intake-scope | context-boundary | verification-contract | review-handoff | behavior-regression | evidence-closeout | external-dependency`
+- Trigger signal:
+- Root cause:
+- Existing guardrail:
+- Recurrence:
+  - `first-seen | repeated | systemic`
+- Current issue disposition:
+  - `repaired-in-scope | approved-with-note | blocked | follow-up-needed`
+- Promotion decision:
+  - `docs-rule | skill | test | ci | template | no-new-guardrail`
+- Guardrail status:
+  - `applied-now | follow-up-created | deferred | no-new-guardrail`
+- Decision rationale:
+- Guardrail change or follow-up asset:
+- Owner / next action:
+- Evidence:
+- Notes:
+```
+
+## Writing Rules
+
+- 한 entry에는 root cause 하나만 적는다.
+- `Trigger signal`은 symptom이고, `Root cause`는 반복될 이유다.
+- `Existing guardrail`에는 이미 있던 policy, template, test, CI, skill이 있으면 적고, 없으면 `없음`이라고 적는다.
+- `Promotion decision`과 `Guardrail status`를 함께 적어 "무엇으로 승격할지"와 "이번 issue에서 적용됐는지"를 분리한다.
+- `no-new-guardrail`을 고르면 `Decision rationale`에 왜 추가 guardrail이 필요 없는지 반드시 적는다.
+- follow-up이 필요하면 `Guardrail change or follow-up asset`에 문서 경로, skill 이름, issue, TODO 중 최소 하나를 적는다.
+
+## Minimal Example
+
+```md
+## Guardrail Ledger Entry
+- Date: `2026-04-07`
+- Task / Exec Plan: `docs/exec-plans/completed/2026-04-07-sample.md`
+- Stage:
+  - `Reviewing`
+- Failure class:
+  - `review-handoff`
+- Trigger signal: reviewer input에 latest verification report 요약이 비어 있었다.
+- Root cause: review handoff minimum이 close-out 형식에서 강제되지 않았다.
+- Existing guardrail: `docs/operations/dual-agent-review-policy.md`
+- Recurrence:
+  - `repeated`
+- Current issue disposition:
+  - `follow-up-needed`
+- Promotion decision:
+  - `template`
+- Guardrail status:
+  - `follow-up-created`
+- Decision rationale: structured field가 비어도 PR close-out이 진행돼 handoff 누락이 반복됐다.
+- Guardrail change or follow-up asset: `.github/PULL_REQUEST_TEMPLATE.md` follow-up
+- Owner / next action: template 정렬 작업에서 reviewer input block을 강화한다.
+- Evidence: PR close-out draft와 review note
+- Notes: policy는 이미 있었고, 입력 강제가 부족했다.
+```

--- a/docs/operations/workflow-governance.md
+++ b/docs/operations/workflow-governance.md
@@ -68,7 +68,7 @@
 - 산출물
 - 검증 명령, 최종 상태, 핵심 evidence
 - 독립 review 결과
-- feedback 또는 후속 guardrail 후보
+- feedback ledger entry 또는 `no new guardrail` 판단
 - 남은 리스크
 - 다음 Issue로 넘겨야 할 전제조건
 
@@ -79,6 +79,7 @@
 - 명령 실행 결과 요약 또는 artifact 위치
 - verification report 최소 필드: contract profile, command별 status, 핵심 evidence, failure summary, next action
 - review evidence 최소 필드: implementer, reviewer, reviewer input, verdict, blocking finding 또는 no-blocking note
+- feedback evidence 최소 필드: stage, failure class, promotion decision, follow-up asset 또는 `no new guardrail` 이유, 핵심 evidence
 - 브라우저 증거: screenshot, trace, video
 - 로그 증거: LogQL 결과 또는 로그 요약
 - 메트릭 증거: PromQL 결과 또는 지표 캡처
@@ -108,6 +109,7 @@
 - PR의 `6) Verification Contract`는 카테고리별 section 아래에 check별 block 형식으로 작성한다.
 - 성공한 검증은 최종 상태와 핵심 evidence만 짧게 적고, 실패, 재시도, 예외만 상세히 남긴다.
 - PR의 `7) Independent Review`는 [dual-agent-review-policy.md](dual-agent-review-policy.md)의 reviewer minimum context와 verdict vocabulary를 따른다.
+- PR의 `9) Feedback / Guardrail Follow-up`는 [failure-to-guardrail-feedback-loop.md](failure-to-guardrail-feedback-loop.md)와 [guardrail-ledger-template.md](guardrail-ledger-template.md)의 vocabulary와 최소 필드를 따른다.
 - 생성 직후에는 `gh issue view --json body` 또는 `gh pr view --json body`로 본문이 예상한 줄바꿈과 섹션을 유지하는지 확인한다.
 - Issue template은 최소한 `문제`, `왜 지금`, `범위/비범위`, `write scope`, `context source`, `verification plan`, `open questions`를 포함해야 한다.
 - PR template은 최소한 `연결된 issue`, `범위/비범위`, `write scope`, `verification 결과`, `독립 review 결과`, `feedback follow-up`, `문서 반영`, `리스크`를 포함해야 한다.

--- a/docs/product/harness-roadmap.md
+++ b/docs/product/harness-roadmap.md
@@ -31,7 +31,7 @@
 5. Implementer Agent는 허용된 도구 경계 안에서만 작업한다.
 6. verification contract registry에 정의된 명령이 통과해야 다음 단계로 넘어간다.
 7. Reviewer Agent는 [../operations/dual-agent-review-policy.md](../operations/dual-agent-review-policy.md)에 따라 구현 diff와 검증 결과를 검토하고, 통과 또는 수정 요청을 결정한다.
-8. 실패한 작업은 feedback ledger에 남기고 다음 가드레일 후보로 전환한다.
+8. 실패한 작업은 [../operations/failure-to-guardrail-feedback-loop.md](../operations/failure-to-guardrail-feedback-loop.md)의 feedback ledger에 남기고 다음 가드레일 후보로 전환한다.
 
 ## 권장 실행 순서
 
@@ -80,3 +80,4 @@
 - 결정론적 검증 없이 Agent의 자기평가를 완료 근거로 삼지 않는다.
 - 구현 Agent는 자기 자신의 결과를 최종 승인하지 않는다.
 - 같은 실패가 반복되면 다음 턴에서는 가드레일이 하나 더 생겨야 한다.
+- `Feedback Pending` close-out에는 guardrail 승격 대상 또는 `no new guardrail` 이유가 남아야 한다.


### PR DESCRIPTION
## 1) Summary
- `Feedback Pending` close-out을 위한 canonical policy를 추가했습니다.
- failure taxonomy, guardrail 승격 규칙, `no new guardrail` 조건, ledger entry template를 source of truth로 고정했습니다.
- operations, architecture, roadmap hook을 새 feedback policy 기준으로 연결했습니다.

## 2) Linked Issue
- Closes #43
- Issue ID: `GRW-17`
- 대상 저장소: `git-ranker-workflow`

## 3) Harness Contract
- Request Type: `policy/governance`
- Context / Source of Truth:
  - `AGENTS.md`
  - `PLANS.md`
  - `docs/operations/workflow-governance.md`
  - `docs/product/work-item-catalog.md`
  - `docs/product/harness-roadmap.md`
  - `docs/architecture/harness-system-map.md`
  - `docs/operations/request-routing-policy.md`
  - `docs/operations/tool-boundary-matrix.md`
  - `docs/operations/verification-contract-registry.md`
  - `docs/operations/dual-agent-review-policy.md`
- Write Scope:
  - `docs/operations/`
  - `docs/architecture/`
  - `docs/product/`
  - `docs/exec-plans/`
- Branch / Exec Plan:
  - `feat/grw-17-failure-to-guardrail-feedback-loop`
  - `docs/exec-plans/active/2026-04-07-grw-17-failure-to-guardrail-feedback-loop.md`

## 4) Scope
- In Scope:
  - failure taxonomy 정의
  - feedback ledger template 추가
  - `Feedback Pending -> Completed` close-out minimum 문서화
  - governance/architecture/roadmap hook 갱신
- Out of Scope:
  - `.github/` template 구조 변경
  - `GRW-S09` skill pack 구현
  - backend/frontend 앱 코드 변경
  - 자동 PR 생성, 자동 복구, CI 구현

## 5) Outputs
- 변경된 문서 / 파일 / 디렉터리:
  - `docs/operations/failure-to-guardrail-feedback-loop.md`
  - `docs/operations/guardrail-ledger-template.md`
  - `docs/operations/README.md`
  - `docs/operations/workflow-governance.md`
  - `docs/architecture/harness-system-map.md`
  - `docs/product/harness-roadmap.md`
  - `docs/exec-plans/active/2026-04-07-grw-17-failure-to-guardrail-feedback-loop.md`
- 후속 작업이 바로 참조할 산출물:
  - feedback ledger vocabulary
  - guardrail promotion decision rule
  - `GRW-S09`, `GRW-18` 입력용 ledger template

## 6) Verification Contract

### Docs / Policy

#### Check Item
- Name: feedback policy 본문 검토
- Command / Check: `sed -n '1,320p' docs/operations/failure-to-guardrail-feedback-loop.md`
- Final Status: `PASS`
- Evidence: failure taxonomy, guardrail 승격 규칙, `no new guardrail` 기준, close-out minimum이 한 문서에 정리됨
- Failure / Exception:

#### Check Item
- Name: ledger template 검토
- Command / Check: `sed -n '1,220p' docs/operations/guardrail-ledger-template.md`
- Final Status: `PASS`
- Evidence: ledger entry 최소 필드, status vocabulary, 예시 형식이 handoff 재사용 가능
- Failure / Exception:

#### Check Item
- Name: hook grep 확인
- Command / Check: `rg -n "feedback|guardrail|ledger|no new guardrail|failure taxonomy|Feedback Pending" docs/operations docs/architecture docs/product docs/exec-plans`
- Final Status: `PASS`
- Evidence: operations/architecture/product/exec plan hook가 함께 grep됨
- Failure / Exception:

#### Check Item
- Name: patch formatting 확인
- Command / Check: `git diff --check`
- Final Status: `PASS`
- Evidence: whitespace/formatting 오류 없음
- Failure / Exception:

### Type / Lint / Test / Build

#### Check Item
- Name: 해당 없음
- Command / Check: 문서 작업
- Final Status: `N/A`
- Evidence: 코드 변경 없음
- Failure / Exception:

### Manual Check

#### Check Item
- Name: 과거 failure 사례 분류
- Command / Check: completed exec plan 3건을 taxonomy와 ledger template로 수동 분류
- Final Status: `PASS`
- Evidence: `evidence-closeout -> template`, `verification-contract -> docs-rule`, `review-handoff -> docs-rule`로 일관되게 분류 가능
- Failure / Exception:

#### Check Item
- Name: GitHub issue body render 확인
- Command / Check: `gh issue view --repo alexization/git-ranker-workflow 43 --json body,title,number`
- Final Status: `PASS`
- Evidence: 이슈 본문 섹션과 줄바꿈 유지 확인
- Failure / Exception:

### Other Task-Specific Contract

#### Check Item
- Name: independent review
- Command / Check: 별도 reviewer handoff 예정
- Final Status: `BLOCKED`
- Evidence: implementer/reviewer 분리 규칙상 draft PR 단계에서는 아직 reviewer 미배정
- Failure / Exception: merge 전 independent review evidence 필요

## 7) Independent Review
- Implementer: `Codex`
- Reviewer: `미배정`
- Reviewer Input:
  - Exec plan: `docs/exec-plans/active/2026-04-07-grw-17-failure-to-guardrail-feedback-loop.md`
  - Latest verification report: `passed`
  - Diff summary: feedback policy/ledger template 추가와 hook 문서 갱신
  - Source-of-truth update: operations, architecture, roadmap 반영 완료
  - Remaining risks / skipped checks: independent review pending
- Review Verdict: `blocked`
- Findings / Change Requests:
  - 별도 reviewer가 아직 없어 dual-agent review close-out을 완료할 수 없음

## 8) Source of Truth Update
- 업데이트한 문서:
  - `docs/operations/failure-to-guardrail-feedback-loop.md`
  - `docs/operations/guardrail-ledger-template.md`
  - `docs/operations/README.md`
  - `docs/operations/workflow-governance.md`
  - `docs/architecture/harness-system-map.md`
  - `docs/product/harness-roadmap.md`
  - `docs/exec-plans/active/2026-04-07-grw-17-failure-to-guardrail-feedback-loop.md`
- 업데이트하지 않은 문서와 사유:
  - `.github/` template는 이번 이슈 비범위라 변경하지 않음

## 9) Feedback / Guardrail Follow-up
- 이번 작업에서 실제로 발생한 실패 / 예외 / 취약 지점:
  - `Feedback Pending` close-out vocabulary와 ledger format 부재
  - independent review는 아직 pending
- 새 guardrail 후보:
  - `docs-rule`: `docs/operations/failure-to-guardrail-feedback-loop.md`
  - `docs-rule`: `docs/operations/guardrail-ledger-template.md`
- 후속 Issue 또는 TODO:
  - `GRW-S09` guardrail-hardening skill pack
  - `GRW-18` workflow repo pilot issue

## 10) Risks and Rollback
- Risks:
  - failure taxonomy가 현장 적용에서 너무 세분화되면 close-out drift가 생길 수 있음
  - review/verification retry semantics와 feedback 승격 판단이 혼동되지 않도록 후속 pilot에서 검증 필요
- Rollback Plan:
  - 새 feedback policy와 hook 문서 변경만 되돌리면 이전 상태로 복귀 가능

## 11) Checklist
- [x] 연결된 Issue가 있다
- [x] Scope / Out of Scope가 적혀 있다
- [x] Write Scope가 적혀 있다
- [x] Verification 최종 상태와 예외가 기입되어 있다
- [ ] Implementer와 Reviewer가 분리되어 있다
- [x] Source of Truth 반영 여부가 적혀 있다
- [x] Feedback 또는 후속 guardrail 후보가 적혀 있다
