### PR TITLE
[GRW-20] PR publish semantics와 pre-PR review 정렬

### DIFF
--- a/docs/architecture/harness-system-map.md
+++ b/docs/architecture/harness-system-map.md
@@ -111,7 +111,7 @@
 
 - Issue는 최소한 `Received`에서 `Planned`까지의 상태를 설명해야 한다.
 - exec plan은 `Planned` 상태의 공식 기록이며, 구현을 시작하기 전에 존재해야 한다.
-- PR은 `Implementing` 이후의 산출물과 `Verifying`, `Reviewing`, `Feedback Pending` 증거를 담는 컨테이너다.
+- PR은 기본적으로 local `Verifying`, `Reviewing`, `Feedback Pending` 결과를 정리한 뒤 publish하는 컨테이너다. 사용자가 예외적으로 요청하지 않았다면 open PR로 게시한다.
 - `Completed` 판정은 PR의 verification 결과와 reviewer verdict, exec plan의 close-out이 함께 있어야 성립한다.
 - 완료된 exec plan은 `docs/exec-plans/completed/`로 옮기고, 후속 Issue가 이 문서를 전제조건으로 참조한다.
 

--- a/docs/exec-plans/completed/2026-04-07-grw-20-pr-publish-review-order.md
+++ b/docs/exec-plans/completed/2026-04-07-grw-20-pr-publish-review-order.md
@@ -1,0 +1,134 @@
+# 2026-04-07-grw-20-pr-publish-review-order
+
+- Issue ID: `GRW-20`
+- GitHub Issue: `#45`
+- Status: `Completed`
+- Repository: `git-ranker-workflow`
+- Branch Name: `feat/grw-20-pr-publish-review-order`
+- Task Slug: `2026-04-07-grw-20-pr-publish-review-order`
+
+## Problem
+
+현재 workflow source of truth는 PR 생성 순서를 `작업 후 PR 생성 -> PR 본문에 review 결과 채우기`처럼 읽히게 적고 있으며, PR을 언제 draft로 만들고 언제 open으로 만들어야 하는지도 명시하지 않는다.
+
+이 상태에서는 사용자가 open PR을 원해도 실행자가 draft를 기본값으로 적용하거나, independent review를 PR 생성 이후의 절차처럼 다루는 drift가 생길 수 있다. dual-agent review의 목적이 "publish 전 독립 검토"라면, review는 기본적으로 PR publish 전에 끝나야 하고 PR에는 이미 latest verification/review evidence가 실린 상태여야 한다.
+
+## Why Now
+
+실제 작업에서 open PR 요청과 draft 기본값이 충돌했고, reviewer 수행 시점도 사용자 기대와 현재 문서 해석 사이에 차이가 드러났다. 이 공백을 그대로 두면 같은 publish/review ordering 혼선이 반복된다.
+
+또한 `Issue 1개 = PR 1개`, `verification`, `independent review`, `feedback`을 하네스 핵심 통제로 두고 있으므로, PR publication semantics와 review ordering을 source of truth로 바로 잠가야 이후 작업이 일관되게 따른다.
+
+## Scope
+
+- PR publish의 기본값을 `open`으로 고정하고, draft는 사용자 명시 요청 또는 선언된 blocker가 있을 때만 허용한다.
+- independent review의 기본 수행 시점을 `pre-PR publish`로 정렬한다.
+- 관련 governance, review policy, architecture, roadmap hook을 갱신한다.
+- 이번 작업 자체는 새 규칙에 맞게 PR publish 전에 독립 review를 먼저 수행한다.
+
+## Non-scope
+
+- GitHub Actions, branch protection, reviewer auto-assignment 구현
+- backend/frontend 앱 코드 변경
+- 기존 `GRW-17` PR 내용 수정
+- `.github/` template 구조 대수선
+
+## Write Scope
+
+- Primary repo: `git-ranker-workflow`
+- Allowed write paths:
+  - `docs/operations/`
+  - `docs/architecture/`
+  - `docs/product/` 필요 시
+  - `docs/exec-plans/`
+- Control-plane artifacts:
+  - `docs/exec-plans/completed/2026-04-07-grw-20-pr-publish-review-order.md`
+  - `.artifacts/2026-04-07-grw-20-pr-publish-review-order/` 필요 시
+- Explicitly forbidden:
+  - sibling app repo code write
+  - 기존 `GRW-17` PR 본문 수정
+  - scope 밖 stable source of truth mass update
+- Network / external systems:
+  - GitHub Issue/PR create/view
+- Escalation triggers:
+  - sandbox가 git stage/commit/push를 막을 때
+
+## Outputs
+
+- PR publication semantics와 pre-PR review ordering을 반영한 source of truth
+- independent review evidence를 포함한 `GRW-20` exec plan
+- open PR default 규칙을 반영한 publish 결과
+
+## Working Decisions
+
+- 이번 작업의 primary context pack은 `workflow-docs`다.
+- PR publication은 기본적으로 review 이후에 수행한다. PR은 review를 받기 위한 초안이 아니라, 최신 verification/review evidence를 publish하는 컨테이너로 본다.
+- draft PR은 기본값이 아니다. 사용자 명시 요청 또는 scope-complete 전 공유가 필요한 blocker가 있을 때만 예외적으로 사용한다.
+- independent review evidence는 PR 생성 전에 먼저 만들고, PR에는 그 결과를 싣는다.
+
+## Verification
+
+- `sed -n '1,260p' docs/operations/workflow-governance.md`
+  - 결과: PR은 기본적으로 open으로 생성하고, independent review 이후 PR body를 채운 뒤 publish하는 순서가 반영된 것을 확인했다.
+- `sed -n '1,260p' docs/operations/dual-agent-review-policy.md`
+  - 결과: PR 존재 여부가 review 선행조건이 아니며, latest review verdict를 PR publish 시점에 싣는다는 규칙이 반영된 것을 확인했다.
+- `sed -n '1,180p' docs/architecture/harness-system-map.md`
+  - 결과: PR projection이 local verification/review/feedback 결과를 정리한 뒤 publish하는 컨테이너로 읽히도록 갱신된 것을 확인했다.
+- `sed -n '1,90p' docs/product/harness-roadmap.md`
+  - 결과: roadmap의 고정 결정에 open-by-default와 pre-PR review publish 순서가 추가된 것을 확인했다.
+- `rg -n "draft PR|open PR|open으로 생성|independent review를 먼저|PR 존재 여부|publish|gh pr create|Independent Review" docs/operations docs/architecture docs/product docs/exec-plans`
+  - 결과: touched 문서의 용어와 순서가 같은 의미로 grep되는 것을 확인했다.
+- `git diff --check`
+  - 결과: whitespace 또는 patch formatting 오류가 없음을 확인했다.
+- GitHub Issue `#45` body render 확인
+  - 결과: issue 본문이 섹션과 줄바꿈을 유지한 채 생성된 것을 확인했다.
+- independent review
+  - 결과: `Gemini CLI (gemini-2.5-flash)` reviewer가 diff와 touched policy 문서를 검토했고 `approved` verdict를 남겼다. blocking inconsistency는 없고, open-by-default와 pre-PR review semantics가 일관되게 반영됐다고 확인했다.
+
+## Evidence
+
+문서 작업이므로 브라우저, 로그, 메트릭 artifact는 필수는 아니다. 대신 아래를 근거로 남긴다.
+
+- publish/review ordering policy 본문
+- hook 문서 갱신 결과
+- independent review evidence
+- `git diff --check` 결과
+- GitHub issue body render 확인 결과
+
+## Independent Review
+
+- Implementer: `Codex`
+- Reviewer: `Gemini CLI (gemini-2.5-flash)`
+- Reviewer Input:
+  - Exec plan: `docs/exec-plans/completed/2026-04-07-grw-20-pr-publish-review-order.md`
+  - Latest verification report: `passed`
+  - Diff summary: governance, review policy, architecture, roadmap에 `open-by-default`와 `pre-PR independent review` semantics 반영
+  - Source-of-truth update: `docs/operations/workflow-governance.md`, `docs/operations/dual-agent-review-policy.md`, `docs/architecture/harness-system-map.md`, `docs/product/harness-roadmap.md`
+  - Remaining risks / skipped checks: publish skill/template 후속 정렬 필요 가능성
+- Review Verdict: `approved`
+- Findings / Change Requests:
+  - blocking finding 없음
+- Evidence:
+  - reviewer는 touched 문서 전반에서 `draft는 예외`, `review는 PR 선행 가능`, `PR은 review/evidence를 싣고 publish` 세 규칙이 서로 충돌 없이 반영됐다고 확인했다.
+
+## Risks or Blockers
+
+- 기존 문서가 PR을 review 진행 중 컨테이너처럼 읽히게 적혀 있어, 한두 문서만 바꾸면 순서가 다시 충돌할 수 있다.
+- open-by-default 규칙을 적더라도 publish skill이나 관성적 절차가 draft를 계속 기본값처럼 쓰면 drift가 남을 수 있다.
+- repo 밖 publish skill 문서나 외부 개인 습관은 이번 수정만으로 자동 정렬되지 않는다.
+
+## Next Preconditions
+
+- 필요 시 publish skill 또는 template 가이드의 후속 정렬
+
+## Docs Updated
+
+- `docs/exec-plans/completed/2026-04-07-grw-20-pr-publish-review-order.md`
+- `docs/operations/workflow-governance.md`
+- `docs/operations/dual-agent-review-policy.md`
+- `docs/architecture/harness-system-map.md`
+- `docs/product/harness-roadmap.md`
+
+## Skill Consideration
+
+이번 작업은 skill을 직접 작성하는 단계는 아니다. 대신 PR publish와 reviewer handoff 순서가 반복적으로 흔들리면 후속 publish/reviewer-handoff skill에서 재사용할 수 있도록 policy와 evidence rule을 먼저 고정한다.

--- a/docs/exec-plans/completed/2026-04-07-grw-20-pr-publish-review-order.md
+++ b/docs/exec-plans/completed/2026-04-07-grw-20-pr-publish-review-order.md
@@ -84,6 +84,9 @@
   - 결과: issue 본문이 섹션과 줄바꿈을 유지한 채 생성된 것을 확인했다.
 - independent review
   - 결과: `Gemini CLI (gemini-2.5-flash)` reviewer가 diff와 touched policy 문서를 검토했고 `approved` verdict를 남겼다. blocking inconsistency는 없고, open-by-default와 pre-PR review semantics가 일관되게 반영됐다고 확인했다.
+- post-PR review repair
+  - 결과: `docs/operations/workflow-governance.md`의 numbered step 7에 blocker-driven draft 예외를 추가해 상단 publish policy와 numbered runbook의 충돌을 해소했다.
+  - 결과: `Gemini CLI (gemini-2.5-flash)` 재검토에서 runbook step과 surrounding policy 사이에 남은 모순이 없다고 확인했다.
 
 ## Evidence
 
@@ -92,6 +95,7 @@
 - publish/review ordering policy 본문
 - hook 문서 갱신 결과
 - independent review evidence
+- post-PR review repair evidence
 - `git diff --check` 결과
 - GitHub issue body render 확인 결과
 

--- a/docs/operations/dual-agent-review-policy.md
+++ b/docs/operations/dual-agent-review-policy.md
@@ -8,6 +8,7 @@
 
 - implementer와 reviewer는 반드시 서로 다른 agent 또는 사람이어야 한다.
 - review는 latest verification report의 overall status가 `passed`이고 reviewer handoff minimum이 채워진 뒤에만 시작할 수 있다.
+- PR 존재 여부는 review의 선행조건이 아니다. 기본 publish 흐름은 local diff와 verification 결과를 먼저 review하고, 그 verdict를 PR에 싣는 순서다.
 - reviewer는 diff만 보지 않고 exec plan, latest verification report, 남은 리스크를 함께 읽어야 한다.
 - reviewer는 현재 issue의 scope, write scope, verification contract, source of truth를 기준으로 판단한다. 새 목표 추가나 범위 확장은 review 단계에서 승인하지 않는다.
 - review evidence는 필수 산출물이다. verdict만 있고 reviewer input이나 finding 근거가 없으면 `Completed` 판정으로 보지 않는다.
@@ -17,14 +18,14 @@
 
 | Role | Must Do | Must Not Do | Required Output |
 | --- | --- | --- | --- |
-| Implementer | exec plan 범위 안에서 변경을 만들고 latest verification report를 준비한다. reviewer에게 diff summary, touched doc, 남은 리스크, conditional command 생략 사유를 넘긴다. review finding이 blocking이면 수정 후 관련 명령을 다시 실행한다. | 자기 결과를 최종 승인하지 않는다. review 전에 verification report 없이 완료를 주장하지 않는다. blocking finding을 non-blocking note로 축소하지 않는다. | diff, latest verification report, reviewer handoff input |
-| Reviewer | implementer와 분리된 관점으로 scope, verification, diff, source-of-truth update, residual risk를 검토한다. finding을 blocking과 non-blocking으로 구분하고 verdict를 남긴다. | implementer 역할까지 겸해 자기 손으로 수정하며 review를 종료하지 않는다. verification이 비어 있는데 승인하지 않는다. 범위 밖 작업을 구두로 끼워 넣지 않는다. | review verdict, findings, review evidence |
+| Implementer | exec plan 범위 안에서 변경을 만들고 latest verification report를 준비한다. reviewer에게 diff summary, touched doc, 남은 리스크, conditional command 생략 사유를 넘긴다. review finding이 blocking이면 수정 후 관련 명령을 다시 실행한다. review verdict가 나오면 그 최신 결과를 PR body에 실어 publish한다. | 자기 결과를 최종 승인하지 않는다. review 전에 verification report 없이 완료를 주장하지 않는다. blocking finding을 non-blocking note로 축소하지 않는다. | diff, latest verification report, reviewer handoff input, publish-ready PR body |
+| Reviewer | implementer와 분리된 관점으로 scope, verification, diff, source-of-truth update, residual risk를 검토한다. finding을 blocking과 non-blocking으로 구분하고 verdict를 남긴다. | implementer 역할까지 겸해 자기 손으로 수정하며 review를 종료하지 않는다. verification이 비어 있는데 승인하지 않는다. 범위 밖 작업을 구두로 끼워 넣지 않는다. PR이 아직 없다는 이유로 review를 미루지 않는다. | review verdict, findings, review evidence |
 
 ## Reviewer Minimum Context
 
 reviewer는 최소한 아래 입력을 받아야 한다.
 
-- exec plan 경로와 linked issue 또는 PR
+- exec plan 경로와 linked issue. PR이 이미 있다면 링크를 추가하고, 아직 없으면 생략 가능하다.
 - latest verification report
 - touched diff summary와 touched file 또는 doc 목록
 - source-of-truth update 목록 또는 "업데이트 불필요" 사유
@@ -127,6 +128,7 @@ review verdict는 PR 본문, review comment, exec plan close-out 중 최소 한 
 - `approved`면 blocking finding이 없다는 점이 드러나야 한다.
 - `changes-requested`면 어떤 수정이 필요한지와 re-run 대상이 드러나야 한다.
 - 문서 전용 issue라도 review evidence를 생략하지 않는다. artifact가 없을 뿐, verdict 근거는 남겨야 한다.
+- PR을 나중에 publish하면 latest review verdict를 그대로 옮겨 적는다. PR 생성이 verdict 시점을 뒤로 미루는 근거가 되지 않는다.
 
 ## Draft Checklist
 

--- a/docs/operations/workflow-governance.md
+++ b/docs/operations/workflow-governance.md
@@ -126,7 +126,7 @@
 4. 이슈 번호를 브랜치명과 exec plan에 연결한다.
 5. 작업 후 latest verification report를 만들고, reviewer minimum context를 준비한 뒤 independent review를 먼저 수행한다.
 6. PR body file에 검증 결과, independent review 결과, 문서 반영 여부, 남은 리스크를 먼저 채운다.
-7. 사용자가 draft를 명시적으로 요청하지 않았다면 `gh pr create --base develop --body-file ...`로 open PR을 연다.
+7. 사용자가 draft를 명시적으로 요청했거나, scope-complete 전 blocker 공유가 필요하면 draft PR을 연다. 그렇지 않다면 `gh pr create --base develop --body-file ...`로 open PR을 연다.
 8. 생성 직후 `gh issue view --json body` 또는 `gh pr view --json body`로 본문 렌더링을 확인한다.
 
 ## 문서, SKILL, exec plan의 역할

--- a/docs/operations/workflow-governance.md
+++ b/docs/operations/workflow-governance.md
@@ -105,6 +105,7 @@
 - GitHub 본문은 먼저 파일로 작성한 뒤 `gh issue create --body-file <path>` 또는 `gh pr create --body-file <path>`로 보낸다.
 - workflow 저장소 Issue 본문은 `.codex/skills/issue-to-exec-plan/templates/github-issue-body.md`를 복사해 채운다.
 - workflow 저장소 PR 본문은 `.github/PULL_REQUEST_TEMPLATE.md`를 복사한 임시 파일을 기준으로 채운다.
+- PR은 기본적으로 open으로 생성한다. draft PR은 사용자가 명시적으로 요청했거나, scope-complete 전 공유가 필요한 blocker를 body와 exec plan에 적을 때만 예외적으로 사용한다.
 - PR의 `6) Verification Contract`는 카테고리별 section 아래에 check별 block 형식으로 작성한다.
 - 성공한 검증은 최종 상태와 핵심 evidence만 짧게 적고, 실패, 재시도, 예외만 상세히 남긴다.
 - PR의 `7) Independent Review`는 [dual-agent-review-policy.md](dual-agent-review-policy.md)의 reviewer minimum context와 verdict vocabulary를 따른다.
@@ -123,9 +124,10 @@
 2. 대상 저장소의 `develop` 최신 상태를 기준으로 worktree 또는 branch를 만든다.
 3. body file을 준비한 뒤 `gh issue create --body-file ...`로 대상 저장소 이슈를 만든다.
 4. 이슈 번호를 브랜치명과 exec plan에 연결한다.
-5. 작업 후 PR body file을 준비하고 `gh pr create --base develop --body-file ...`로 PR을 연다.
-6. 생성 직후 `gh issue view --json body` 또는 `gh pr view --json body`로 본문 렌더링을 확인한다.
-7. PR 본문에 검증 결과, 독립 review 결과, 문서 반영 여부, 남은 리스크를 채운다.
+5. 작업 후 latest verification report를 만들고, reviewer minimum context를 준비한 뒤 independent review를 먼저 수행한다.
+6. PR body file에 검증 결과, independent review 결과, 문서 반영 여부, 남은 리스크를 먼저 채운다.
+7. 사용자가 draft를 명시적으로 요청하지 않았다면 `gh pr create --base develop --body-file ...`로 open PR을 연다.
+8. 생성 직후 `gh issue view --json body` 또는 `gh pr view --json body`로 본문 렌더링을 확인한다.
 
 ## 문서, SKILL, exec plan의 역할
 
@@ -148,6 +150,7 @@
 - network나 escalation이 필요하면 목적과 범위를 exec plan 또는 최종 close-out에 남긴다.
 - verification failure가 나면 registry의 retry budget 안에서만 repair loop를 돌리고, budget 초과나 missing canonical source는 `Blocked` 또는 후속 planning으로 넘긴다.
 - review 단계에 들어가기 전 latest verification report와 reviewer minimum context를 준비한다.
+- 사용자가 다르게 요청하지 않았다면 independent review를 끝낸 뒤 PR을 publish한다.
 - source of truth 문서를 함께 업데이트하거나, 업데이트가 불필요한 이유를 남긴다.
 - 검증 명령과 최종 상태를 반드시 남기고, 실패나 예외가 있었다면 요약을 남긴다.
 - 새로 생긴 반복 절차가 있다면 skill 후보로 제안하되, 이번 Issue 범위를 넘는 구현은 하지 않는다.

--- a/docs/product/harness-roadmap.md
+++ b/docs/product/harness-roadmap.md
@@ -19,6 +19,7 @@
 - 구현 Agent와 review Agent는 역할을 분리한다.
 - source of truth는 `workflow 중심`으로 유지하되, 앱 동작의 canonical source는 각 앱 저장소 코드와 테스트에 둔다.
 - 새 작업은 항상 exec plan으로 고정한 뒤 시작한다.
+- 사용자가 다르게 요청하지 않으면 PR은 independent review와 feedback evidence를 먼저 채운 뒤 open 상태로 publish한다.
 
 ## 목표 상태
 


### PR DESCRIPTION
## 1) Summary
- PR publish semantics를 `open-by-default`로 정렬했습니다.
- independent review를 기본적으로 PR publish 전에 수행하고, PR에는 이미 검증/리뷰 evidence가 들어간 상태로 게시하도록 source of truth를 수정했습니다.
- governance, review policy, architecture, roadmap이 같은 순서를 가리키도록 맞췄습니다.

## 2) Linked Issue
- Closes #45
- Issue ID: `GRW-20`
- 대상 저장소: `git-ranker-workflow`

## 3) Harness Contract
- Request Type: `policy/governance`
- Context / Source of Truth:
  - `AGENTS.md`
  - `PLANS.md`
  - `docs/operations/workflow-governance.md`
  - `docs/operations/dual-agent-review-policy.md`
  - `docs/operations/verification-contract-registry.md`
  - `docs/architecture/harness-system-map.md`
  - `docs/product/harness-roadmap.md`
  - `.github/PULL_REQUEST_TEMPLATE.md`
- Write Scope:
  - `docs/operations/`
  - `docs/architecture/`
  - `docs/product/`
  - `docs/exec-plans/`
- Branch / Exec Plan:
  - `feat/grw-20-pr-publish-review-order`
  - `docs/exec-plans/completed/2026-04-07-grw-20-pr-publish-review-order.md`

## 4) Scope
- In Scope:
  - open PR 기본값과 draft 예외 규칙 문서화
  - independent review의 기본 수행 시점을 pre-PR publish로 정렬
  - governance / review policy / architecture / roadmap hook 갱신
- Out of Scope:
  - GitHub Actions, branch protection, reviewer auto-assignment 구현
  - backend/frontend 앱 코드 변경
  - 기존 `GRW-17` PR 수정
  - `.github/` template 구조 대수선

## 5) Outputs
- 변경된 문서 / 파일 / 디렉터리:
  - `docs/operations/workflow-governance.md`
  - `docs/operations/dual-agent-review-policy.md`
  - `docs/architecture/harness-system-map.md`
  - `docs/product/harness-roadmap.md`
  - `docs/exec-plans/completed/2026-04-07-grw-20-pr-publish-review-order.md`
- 후속 작업이 바로 참조할 산출물:
  - open-by-default PR publication rule
  - pre-PR independent review ordering rule
  - completed exec plan with independent review evidence

## 6) Verification Contract

### Docs / Policy

#### Check Item
- Name: governance publish 규칙 확인
- Command / Check: `sed -n '96,170p' docs/operations/workflow-governance.md`
- Final Status: `PASS`
- Evidence: open PR 기본값, draft 예외, pre-PR review 후 publish 순서가 반영됐고 numbered step 7에도 blocker-driven draft 예외가 포함됨
- Failure / Exception:

#### Check Item
- Name: dual-agent review policy 확인
- Command / Check: `sed -n '1,220p' docs/operations/dual-agent-review-policy.md`
- Final Status: `PASS`
- Evidence: PR 존재 여부는 review 선행조건이 아니며, latest verdict를 PR publish 시점에 싣는다고 명시됨
- Failure / Exception:

#### Check Item
- Name: architecture / roadmap hook 확인
- Command / Check: `sed -n '108,118p' docs/architecture/harness-system-map.md` / `sed -n '1,90p' docs/product/harness-roadmap.md`
- Final Status: `PASS`
- Evidence: PR projection과 roadmap의 고정 결정이 같은 publish ordering을 가리킴
- Failure / Exception:

#### Check Item
- Name: hook grep 확인
- Command / Check: `rg -n "draft PR|open PR|open으로 생성|independent review를 먼저|PR 존재 여부|publish|gh pr create|Independent Review" docs/operations docs/architecture docs/product docs/exec-plans`
- Final Status: `PASS`
- Evidence: touched 문서 전반에서 동일 vocabulary와 순서 확인
- Failure / Exception:

#### Check Item
- Name: patch formatting 확인
- Command / Check: `git diff --check`
- Final Status: `PASS`
- Evidence: whitespace/formatting 오류 없음
- Failure / Exception:

### Type / Lint / Test / Build

#### Check Item
- Name: 해당 없음
- Command / Check: 문서 작업
- Final Status: `N/A`
- Evidence: 코드 변경 없음
- Failure / Exception:

### Manual Check

#### Check Item
- Name: GitHub issue body render 확인
- Command / Check: `gh issue view --repo alexization/git-ranker-workflow 45 --json body,title,number`
- Final Status: `PASS`
- Evidence: issue 본문 섹션과 줄바꿈 유지 확인
- Failure / Exception:

#### Check Item
- Name: independent review 선행 수행
- Command / Check: `Gemini CLI (gemini-2.5-flash)` reviewer로 diff와 touched policy 문서 검토
- Final Status: `PASS`
- Evidence: `approved` verdict, blocking inconsistency 없음
- Failure / Exception:

#### Check Item
- Name: post-PR review repair 재검토
- Command / Check: reviewer comment 반영 후 `Gemini CLI (gemini-2.5-flash)`로 workflow-governance 재검토
- Final Status: `PASS`
- Evidence: numbered runbook step과 surrounding policy 사이에 남은 모순 없음
- Failure / Exception:

### Other Task-Specific Contract

#### Check Item
- Name: PR publish mode
- Command / Check: open PR 생성
- Final Status: `PASS`
- Evidence: 사용자 요청에 맞춰 draft가 아닌 open PR로 publish
- Failure / Exception:

## 7) Independent Review
- Implementer: `Codex`
- Reviewer: `Gemini CLI (gemini-2.5-flash)`
- Reviewer Input:
  - Exec plan: `docs/exec-plans/completed/2026-04-07-grw-20-pr-publish-review-order.md`
  - Latest verification report: `passed`
  - Diff summary: governance, review policy, architecture, roadmap에 open-by-default와 pre-PR review semantics 반영
  - Source-of-truth update: workflow-governance, dual-agent-review-policy, harness-system-map, harness-roadmap
  - Remaining risks / skipped checks: publish skill/template 후속 정렬 필요 가능성
- Review Verdict: `approved`
- Findings / Change Requests:
  - blocking finding 없음
  - post-PR review에서 지적된 blocker-driven draft 예외 누락 반영 완료

## 8) Source of Truth Update
- 업데이트한 문서:
  - `docs/operations/workflow-governance.md`
  - `docs/operations/dual-agent-review-policy.md`
  - `docs/architecture/harness-system-map.md`
  - `docs/product/harness-roadmap.md`
  - `docs/exec-plans/completed/2026-04-07-grw-20-pr-publish-review-order.md`
- 업데이트하지 않은 문서와 사유:
  - `.github/` template는 현재 문구만으로도 prefilled review evidence를 담을 수 있어 이번 이슈에서는 구조 변경이 불필요함

## 9) Feedback / Guardrail Follow-up
- 이번 작업에서 실제로 발생한 실패 / 예외 / 취약 지점:
  - open PR 요청인데 draft 기본값이 적용될 수 있는 publish drift
  - independent review가 PR 생성 이후 절차처럼 읽히는 ordering ambiguity
- 새 guardrail 후보:
  - `docs-rule`: workflow governance publish ordering 교정
  - `docs-rule`: dual-agent review policy에 pre-PR review semantics 명시
- 후속 Issue 또는 TODO:
  - 필요 시 publish skill 또는 template 가이드 정렬

## 10) Risks and Rollback
- Risks:
  - repo 밖 publish 습관이나 외부 skill 문서는 이번 PR만으로 자동 정렬되지 않음
  - 향후 template나 publish helper가 다른 기본값을 갖고 있으면 재드리프트 가능
- Rollback Plan:
  - 이번 PR의 문서 다섯 파일만 되돌리면 이전 publish/review 순서로 복귀 가능

## 11) Checklist
- [x] 연결된 Issue가 있다
- [x] Scope / Out of Scope가 적혀 있다
- [x] Write Scope가 적혀 있다
- [x] Verification 최종 상태와 예외가 기입되어 있다
- [x] Implementer와 Reviewer가 분리되어 있다
- [x] Source of Truth 반영 여부가 적혀 있다
- [x] Feedback 또는 후속 guardrail 후보가 적혀 있다
