### PR TITLE
[Task] GRW-S06 intake/ambiguity skill pack

### DIFF
--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -8,6 +8,13 @@
 - 반복 작업을 매번 자연어로 다시 설명하지 않게 한다.
 - 문서, exec plan, evidence 규칙을 실행 절차와 연결한다.
 
+## Canonical Ownership
+
+- 정책, vocabulary, 상태 전이, 종료 조건, evidence minimum은 `docs/operations/`, `docs/architecture/`, `docs/product/`의 source of truth가 관리한다.
+- skill은 그 정책을 대체하지 않고, 한 단계의 반복 실행 절차와 handoff만 다룬다.
+- registry 문서는 "지금 어떤 skill이 있고 어떤 순서로 쓰는가"만 관리한다. roadmap task ID나 진행 상태는 여기서 추적하지 않는다.
+- policy와 skill이 충돌하면 skill에 새 규칙을 더하지 말고 canonical policy를 먼저 수정한 뒤 skill을 맞춘다.
+
 ## 기본 구조
 
 - 실제 skill은 `.codex/skills/<skill-name>/SKILL.md` 구조를 사용한다.
@@ -71,20 +78,31 @@
 
 현재 등록된 project skill은 아래와 같다.
 
-- `issue-to-exec-plan` (`GRW-S02`): 새 Issue를 `docs/exec-plans/active/*.md` 실행 문서로 고정할 때 사용
-- `parallel-work-split` (`GRW-S02`): 여러 agent가 같은 Issue를 나눠 작업하기 전에 ownership과 write set을 분리할 때 사용
-- `api-contract-sync` (`GRW-S02`): backend OpenAPI 변경을 client 타입과 workflow 문서에 동기화할 때 사용
-- `red` (`GRW-S05`): failing test file 하나만 남기는 TDD red turn
-- `green` (`GRW-S05`): test 수정 없이 최소 구현으로 green을 만드는 턴
-- `refactor` (`GRW-S05`): green 유지 하에 구조를 정리하는 refactor 턴
+- `request-intake`: 새 요청을 `대화`, `모호한 요청`, `즉시 실행 가능한 작업`으로 분류하고 다음 행동을 고정할 때 사용
+- `ambiguity-interview`: `모호한 요청`을 한 issue로 줄이거나 `Blocked`/`Rejected`로 닫을 때 사용
+- `issue-to-exec-plan`: 새 Issue를 `docs/exec-plans/active/*.md` 실행 문서로 고정할 때 사용
+- `parallel-work-split`: 여러 agent가 같은 Issue를 나눠 작업하기 전에 ownership과 write set을 분리할 때 사용
+- `api-contract-sync`: backend OpenAPI 변경을 client 타입과 workflow 문서에 동기화할 때 사용
+- `red`: failing test file 하나만 남기는 TDD red turn
+- `green`: test 수정 없이 최소 구현으로 green을 만드는 턴
+- `refactor`: green 유지 하에 구조를 정리하는 refactor 턴
 
 ## Recommended Use
 
-coordination skill은 구현 전에 먼저 쓴다.
+새 요청을 처음 받을 때의 기본 순서는 아래와 같다.
 
-1. `issue-to-exec-plan`
-2. `parallel-work-split`
-3. `api-contract-sync` if backend contract changed
+1. `request-intake`
+2. `ambiguity-interview` if route is `모호한 요청`
+3. `issue-to-exec-plan` if route is `즉시 실행 가능한 작업` or interview exits `Planned`
+4. `parallel-work-split` if more than one agent will work on the same issue
+
+아래 skill은 기본 진입 순서가 아니라 조건부 hook으로 사용한다.
+
+- `api-contract-sync` if backend contract changed
+
+close-out이 `Rejected`이거나 route가 `대화`로 끝나면 issue, exec plan, 파일 편집을 시작하지 않는다.
+
+범위가 이미 issue/exec plan 수준으로 잠긴 작업은 `issue-to-exec-plan`부터 시작해도 된다.
 
 구현 skill은 그 다음 slice에 맞춰 쓴다.
 
@@ -94,14 +112,7 @@ coordination skill은 구현 전에 먼저 쓴다.
 
 `api-contract-sync`의 canonical backend contract는 `git-ranker/docs/openapi/openapi.json`이다. workflow는 canonical spec을 복제해 소유하지 않고, sync 절차와 evidence를 관리한다.
 
-현재 등록된 skill은 그대로 유지하되, 후속 skill pack의 방향은 더 이상 ranking harness 중심으로 확장하지 않는다.
-
-후속 작업에서는 아래 순서로 새 skill pack을 채운다.
-
-- `GRW-S06`: `request-intake`, `ambiguity-interview`
-- `GRW-S07`: `context-pack-selection`, `boundary-check`
-- `GRW-S08`: `verification-contract-runner`, `repair-loop-triage`, `reviewer-handoff`
-- `GRW-S09`: `guardrail-ledger-update`, `failure-to-policy`
+새 skill을 추가할 때는 roadmap item이나 task ID가 아니라 asset 이름과 workflow 역할만 registry에 남긴다.
 
 구현 결과의 최종 승인은 구현 Agent가 아니라 별도 review Agent가 담당한다.
 

--- a/.codex/skills/ambiguity-interview/SKILL.md
+++ b/.codex/skills/ambiguity-interview/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: ambiguity-interview
+description: Use this skill when request intake returns `모호한 요청` and you must reduce the remaining blockers into a single executable issue, `Blocked`, or `Rejected`.
+---
+
+# Ambiguity Interview
+
+## Purpose
+
+`모호한 요청`으로 분류된 작업에서 남은 ambiguity signal을 줄여 한 issue로 고정 가능한 입력을 만든다. 목표는 요구사항을 늘리는 것이 아니라 문제 정의, 범위, write scope, 산출물, verification을 잠그는 것이다.
+
+## Trigger
+
+- `request-intake` 결과가 `모호한 요청`이다.
+- source of truth만으로는 하나 이상의 ambiguity signal이 남아 있다.
+- 어떤 질문을 해야 issue/exec plan 가능한 상태로 수렴하는지 정리해야 한다.
+
+## Inputs and Preconditions
+
+- 최신 사용자 요청 또는 issue draft
+- `request-intake` summary
+- `docs/operations/request-routing-policy.md`
+- 관련 product 문서, 기존 exec plan, 저장소 entry 문서
+- 어떤 ambiguity signal이 남았는지 이미 적어 둘 수 있어야 한다.
+- interview 전에 source of truth로 줄일 수 있는 사실은 먼저 줄인다.
+
+## Canonical Boundary
+
+- interview objective, question rule, exit condition, canonical close-out reason은 `docs/operations/request-routing-policy.md`가 관리한다.
+- 이 skill은 남아 있는 ambiguity를 어떤 순서로 줄이고 어떤 exit summary를 남길지 operationalize한다.
+- 새 종료 상태나 새 close-out reason이 필요해 보이면 skill에 추가하지 말고 policy를 먼저 갱신한다.
+
+## Output and Artifact Location
+
+- 산출물은 interview exit summary다. 기본적으로 응답이나 작업 메모에 남기고, 종료 상태에 따라 다음 단계가 갈린다.
+- `Planned`
+  - issue 본문과 exec plan의 `Problem`, `Why Now`, `Scope`, `Non-scope`, `Write Scope`, `Verification`을 채울 수 있는 요약을 남긴다.
+  - 다음 단계는 `issue-to-exec-plan`이다.
+- `Blocked`
+  - 현재 issue 안에서 더 줄일 수 없는 blocker와 필요한 외부 입력을 남긴다.
+- `Rejected`
+  - canonical close-out reason을 남기고 실행을 종료한다.
+
+## Standard Commands
+
+반복적으로 확인하는 기본 명령 예시:
+
+```bash
+sed -n '1,260p' docs/operations/request-routing-policy.md
+rg -n "<repo|surface noun|issue-id>" docs/product docs/exec-plans docs .codex/skills
+sed -n '1,220p' <candidate-source-of-truth>
+```
+
+핵심은 "질문 전에 source를 더 읽어 ambiguity를 줄일 수 있는가"를 먼저 확인하는 것이다.
+
+## Required Evidence
+
+- 남아 있는 ambiguity signal 목록
+- 질문 전에 읽은 source of truth
+- 실제로 사용자에게 던진 blocker 질문
+- interview exit status: `Planned`, `Blocked`, `Rejected`
+- 종료 근거
+  - `Planned`: 고정된 문제/범위/write scope/verification
+  - `Blocked`: 어떤 canonical source나 응답이 비어 있는지
+  - `Rejected`: `docs/operations/request-routing-policy.md`의 canonical close-out reason 중 무엇을 적용했는지
+
+## Forbidden Shortcuts
+
+- 한 번에 긴 설문을 던지지 않는다.
+- 요구사항을 더 크게 만들거나 새 기능 아이디어를 제안하지 않는다.
+- source of truth에 없는 제품/설계 선호를 대신 결정하지 않는다.
+- `Planned`가 되기 전에는 issue 생성, exec plan 작성, 파일 편집을 시작하지 않는다.
+- 같은 ambiguity signal이 두 번 남았는데도 더 많은 질문으로 밀어붙이지 않는다.
+
+## Parallel Ownership Rule
+
+- 같은 interview thread는 한 agent만 소유한다.
+- 다른 agent가 다른 가정으로 병렬 질문을 던지지 않는다.
+- interview owner가 종료 상태를 고정하기 전에는 planning owner나 implementation owner가 범위를 확장하지 않는다.
+
+## Interview Rules
+
+- interview 규칙 자체는 `docs/operations/request-routing-policy.md`를 그대로 따른다.
+- operational focus만 정리하면 아래와 같다.
+  - 한 라운드에는 blocker 하나를 우선 줄인다.
+  - 여러 저장소나 여러 목표가 섞였으면 primary repo나 첫 issue를 먼저 고정한다.
+  - 기본 결정이 이미 source of truth에 있으면 그 결정을 재질문하지 않는다.
+  - 같은 ambiguity signal이 두 라운드 뒤에도 남으면 더 묻지 말고 `Blocked` 또는 `Rejected`로 정리한다.
+
+## Example Input
+
+- 요청: "backend랑 client 인증 흐름 다 정리하고 필요한 것들 한 번에 고쳐줘"
+- `request-intake` 결과:
+  - route: `모호한 요청`
+  - ambiguity:
+    - 여러 저장소가 섞여 있음
+    - 여러 목표가 한 issue로 묶여 있음
+
+## Example Output
+
+```md
+Interview question
+- "이번 턴의 primary repo를 먼저 `git-ranker`와 `git-ranker-client` 중 어디로 고정할까요?"
+
+사용자 응답 이후 exit summary 예시
+- Status: `Planned`
+- Primary repo: `git-ranker`
+- Problem: backend 인증 흐름 정리
+- Non-scope: client UI 수정
+- Next action: `issue-to-exec-plan`
+```
+
+## Handoff
+
+interview 종료 후 아래를 넘긴다.
+
+- `Planned`
+  - 문제 정의
+  - 왜 지금 필요한지
+  - 범위와 비범위
+  - 대상 저장소와 write scope
+  - 기대 산출물
+  - verification 방법
+  - 다음 단계: `issue-to-exec-plan`
+- `Blocked`
+  - 남은 blocker
+  - 필요한 외부 입력 또는 canonical source
+- `Rejected`
+  - canonical close-out reason
+  - 실행을 계속하지 않는 이유

--- a/.codex/skills/authoring-rules.md
+++ b/.codex/skills/authoring-rules.md
@@ -10,6 +10,14 @@
 - 후속 에이전트가 같은 절차를 재사용할 수 있을 정도로만 구체적으로 쓴다.
 - 구조보다 판단 기준과 금지 사항을 우선 명확히 쓴다.
 
+## Policy / Skill Boundary
+
+- 상태 이름, taxonomy, stop condition, evidence minimum, close-out reason 같은 canonical rule은 `docs/` 아래 source of truth가 소유한다.
+- skill은 그 rule을 "어떤 순서로 적용하고 무엇을 handoff할지"만 operationalize한다.
+- skill이 policy 표나 vocabulary를 길게 다시 쓰기 시작하면 중복 신호로 보고 줄인다.
+- 새 규칙이 필요하면 skill에서 발명하지 말고 policy 문서를 먼저 갱신한 뒤 skill을 맞춘다.
+- `.codex/skills/README.md`와 `authoring-rules.md` 같은 관리 문서는 roadmap task ID나 진행 상태를 추적하지 않는다.
+
 ## Required Coverage
 
 각 `SKILL.md`는 섹션 이름이 완전히 같을 필요는 없지만, 아래 항목을 반드시 다뤄야 한다.
@@ -28,6 +36,7 @@
 - 서두에서 관련 source of truth 문서를 먼저 읽게 한다.
 - 모든 skill에 같은 boilerplate `Read First` 섹션을 반복하지 않는다. 실제로 이 skill에서만 꼭 읽어야 하는 문서가 있을 때만 적는다.
 - `workflow governance`, `authoring rules` 같은 공통 문서는 필요할 때 precondition이나 relevant docs로 간단히 언급하고, 매 skill마다 기계적으로 복붙하지 않는다.
+- policy 표나 종료 조건 목록을 통째로 복사하지 말고, canonical 문서를 참조한 뒤 skill에 필요한 operational hook만 남긴다.
 - 명령은 실제로 반복 실행 가능한 수준으로 구체적으로 적는다.
 - 증거 규칙은 "가능하면"이 아니라 "최소 무엇은 남겨야 한다" 수준으로 적는다.
 - 금지 사항은 모호하게 쓰지 말고, 어떤 우회를 막는지 분명히 적는다.
@@ -60,6 +69,7 @@ description: One-line trigger and purpose summary.
 - 현재 Issue의 write scope를 넘는 파일 변경을 skill에서 정당화하지 않는다.
 - "언젠가 필요할 수도 있는" 절차까지 미리 넣지 않는다.
 - source of truth 문서 업데이트가 필요한 경우, 해당 문서 반영 또는 반영 불필요 사유를 함께 남긴다.
+- registry나 management 문서에 현재 task ID, 진행 상태, 후속 roadmap 순서를 직접 남기지 않는다.
 
 ## Review Checklist
 

--- a/.codex/skills/issue-to-exec-plan/SKILL.md
+++ b/.codex/skills/issue-to-exec-plan/SKILL.md
@@ -39,12 +39,12 @@ description: Use this skill when a roadmap item or GitHub issue must be turned i
 반복적으로 확인하는 기본 명령 예시:
 
 ```bash
-rg -n "GRW-S02|GRC-04|GRB-02" docs/product docs/exec-plans
+rg -n "<issue-id|task-slug|surface noun>" docs/product docs/exec-plans
 find docs/exec-plans/active docs/exec-plans/completed -maxdepth 1 -type f | sort
 cp .codex/skills/issue-to-exec-plan/templates/github-issue-body.md /tmp/<issue-id>-issue-body.md
 gh issue create --repo <owner>/<target-repo> --title "[Task] <issue-id> ..." --body-file /tmp/<issue-id>-issue-body.md
 gh issue view --repo <owner>/<target-repo> <issue-number> --json body
-git checkout -b feat/grw-s02-core-planning-skill-pack
+git checkout -b feat/<issue-id-lower>-<slug>
 ```
 
 명령 자체보다 중요한 것은 "어떤 문서를 읽고 어떤 범위를 고정했는지"를 exec plan에 남기는 것이다.
@@ -89,34 +89,34 @@ workflow 저장소에서 멀티라인 Issue 본문을 만들 때는 `.codex/skil
 
 ## Example Input
 
-- Issue: `GRC-04`
-- Goal: ranking read Playwright harness 도입
+- Issue: `<issue-id>`
+- Goal: target harness 도입
 - Relevant docs:
   - `docs/product/work-item-catalog.md`
-  - `docs/domain/frontend-data-flows.md`
-  - `docs/operations/frontend-runtime-reference.md`
-  - `docs/exec-plans/completed/2026-03-25-grw-04-frontend-routes-data-flow-docs.md`
+  - `docs/domain/<relevant-domain-doc>.md`
+  - `docs/operations/<relevant-runtime-doc>.md`
+  - `docs/exec-plans/completed/<previous-related-plan>.md`
 
 ## Example Output
 
 ```md
-# 2026-03-26-grc-04-ranking-read-playwright-harness
+# <date>-<issue-id-lower>-<slug>
 
-- Issue ID: `GRC-04`
+- Issue ID: `<issue-id>`
 - Status: `Ready`
 
 ## Scope
-- Playwright config 추가
-- ranking read spec 추가
+- target config 추가
+- target spec 추가
 - artifact 규칙 연결
 
 ## Non-scope
-- 인증 포함 전체 여정 자동화
+- unrelated full user journey automation
 - 디자인 변경
 
 ## Verification
-- `npm run playwright -- ranking-read`
-- trace/screenshot 생성 확인
+- `<verification-command>`
+- required artifact 생성 확인
 ```
 
 ## Handoff

--- a/.codex/skills/parallel-work-split/SKILL.md
+++ b/.codex/skills/parallel-work-split/SKILL.md
@@ -83,11 +83,11 @@ git -C git-ranker-client status --short
 
 ## Example Input
 
-- Issue: `GRC-04`
-- Goal: ranking read Playwright harness
+- Issue: `<issue-id>`
+- Goal: route-level E2E harness
 - Known write scope:
-  - `git-ranker-client/playwright.config.*`
-  - `git-ranker-client/tests/**`
+  - `<target-repo>/<config-file>`
+  - `<target-repo>/<test-dir>/**`
   - 최소 test hook 후보 파일
   - workflow 문서의 artifact 규칙
 
@@ -96,12 +96,12 @@ git -C git-ranker-client status --short
 ```md
 | owner | repo | goal | write set | handoff |
 | --- | --- | --- | --- | --- |
-| main | git-ranker-client | Playwright base config | `playwright.config.ts`, package script | config green 후 spec owner로 전달 |
-| agent-a | git-ranker-client | ranking read spec | `tests/ranking-read.spec.ts` | config merge 기준에 맞춰 spec 작성 |
-| agent-b | git-ranker-workflow | artifact/doc 연결 | `docs/exec-plans/...`, workflow artifact note | spec path와 artifact path 확인 후 문서 반영 |
+| main | `<target-repo>` | base config | `<config-file>`, package script | config green 후 spec owner로 전달 |
+| agent-a | `<target-repo>` | route spec | `<test-spec-file>` | config merge 기준에 맞춰 spec 작성 |
+| agent-b | `git-ranker-workflow` | artifact/doc 연결 | `docs/exec-plans/...`, workflow artifact note | spec path와 artifact path 확인 후 문서 반영 |
 ```
 
-이 예시에서 `playwright.config.ts`는 main owner만 수정한다. config가 고정되기 전에는 spec과 workflow artifact 문서를 병렬로 밀어붙이지 않는다.
+이 예시에서 `<config-file>`은 main owner만 수정한다. config가 고정되기 전에는 spec과 workflow artifact 문서를 병렬로 밀어붙이지 않는다.
 
 ## Handoff
 

--- a/.codex/skills/request-intake/SKILL.md
+++ b/.codex/skills/request-intake/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: request-intake
+description: Use this skill when a new request arrives and you must classify it as `대화`, `모호한 요청`, or `즉시 실행 가능한 작업` before creating an issue, exec plan, or file edits.
+---
+
+# Request Intake
+
+## Purpose
+
+새 요청을 intake 단계에서 `대화`, `모호한 요청`, `즉시 실행 가능한 작업` 중 하나로 고정하고, route에 맞는 다음 행동만 남긴다. 목표는 구현 아이디어를 늘리는 것이 아니라 "지금 실행을 시작해도 되는가"를 같은 기준으로 판정하는 것이다.
+
+## Trigger
+
+- 새 사용자 요청이 들어왔다.
+- 아직 GitHub issue, active exec plan, 파일 편집을 시작하지 않았다.
+- 요청이 응답형 대화인지, interview가 필요한지, 바로 실행 가능한 작업인지 먼저 판정해야 한다.
+
+## Inputs and Preconditions
+
+- 최소한 아래 입력을 먼저 확인한다.
+  - 최신 사용자 요청 또는 issue body
+  - `docs/operations/request-routing-policy.md`
+  - `docs/operations/workflow-governance.md`
+  - 관련 `docs/product/*.md` 또는 기존 exec plan이 있으면 해당 문서
+- source of truth로 줄일 수 있는 ambiguity는 먼저 직접 줄인다.
+- 대상 저장소, 산출물, write scope, verification을 source of truth만으로 잠글 수 있는지 본다.
+- intake 단계에서는 아직 issue를 만들거나 exec plan을 쓰지 않는다.
+
+## Canonical Boundary
+
+- route taxonomy, ambiguity signal, immediate execution criteria, `Rejected` semantics는 `docs/operations/request-routing-policy.md`가 canonical source다.
+- 이 skill은 canonical route를 새로 정의하지 않고, 현재 요청이 어느 route에 해당하는지와 다음 handoff만 남긴다.
+- policy와 skill 문구가 어긋나면 skill보다 policy를 먼저 수정하고 다시 맞춘다.
+
+## Output and Artifact Location
+
+- 산출물은 route decision summary다. 기본적으로 응답이나 작업 메모에 남긴다.
+- route별 다음 행동은 canonical policy를 그대로 따르되, skill output에는 아래 handoff만 남긴다.
+  - `대화`: 답변만 제공하고 종료
+  - `모호한 요청`: 남아 있는 ambiguity signal과 첫 interview blocker를 정리해 `ambiguity-interview`로 넘김
+  - `즉시 실행 가능한 작업`: 문제, 범위, write scope, verification 요약을 정리해 `issue-to-exec-plan`으로 넘김
+
+## Standard Commands
+
+반복적으로 확인하는 기본 명령 예시:
+
+```bash
+sed -n '1,260p' docs/operations/request-routing-policy.md
+sed -n '1,220p' docs/operations/workflow-governance.md
+rg -n "<issue-id|task-name|surface noun>" docs/product docs/exec-plans .codex/skills
+find docs/exec-plans/active docs/exec-plans/completed -maxdepth 1 -type f | sort
+```
+
+중요한 점은 명령을 많이 돌리는 것이 아니라, route 판정에 필요한 canonical source를 먼저 읽고 판단 근거를 남기는 것이다.
+
+## Required Evidence
+
+- 어떤 source of truth 문서를 읽었는지
+- 최종 route: `대화`, `모호한 요청`, `즉시 실행 가능한 작업`
+- 남아 있는 ambiguity signal 또는 제거된 ambiguity 근거
+- 다음 행동
+  - `대화`: 답변만 제공하고 종료
+  - `모호한 요청`: `ambiguity-interview`
+  - `즉시 실행 가능한 작업`: `issue-to-exec-plan`
+- `즉시 실행 가능한 작업`이 아니면 왜 issue/exec plan을 만들지 않았는지
+
+## Forbidden Shortcuts
+
+- source of truth를 읽기 전에 사용자에게 바로 여러 질문을 던지지 않는다.
+- `즉시 실행 가능한 작업`으로 판정되기 전에는 issue, exec plan, 파일 편집을 시작하지 않는다.
+- 여러 목표가 섞인 요청을 임의로 한 issue로 묶지 않는다.
+- verification이나 write scope를 문서 근거 없이 상상해서 채우지 않는다.
+- `대화` 요청을 구현 요청처럼 취급하지 않는다.
+
+## Parallel Ownership Rule
+
+- 최종 route decision summary는 한 agent만 소유한다.
+- route가 잠기기 전에는 다른 agent가 issue 생성, exec plan 작성, 구현 착수를 병렬로 시작하지 않는다.
+- `모호한 요청`으로 판정된 뒤에는 interview owner가 ambiguity를 줄이고, `즉시 실행 가능한 작업`으로 수렴한 뒤에만 planning owner에게 넘긴다.
+
+## Example Input
+
+- 요청: "랭킹 화면 좀 개선해줘"
+- source 확인 결과:
+  - 대상 저장소 불명확
+  - 완료 조건 부재
+  - write scope 부재
+
+## Example Output
+
+```md
+Route: `모호한 요청`
+
+남아 있는 ambiguity signal
+- 대상 저장소가 고정되지 않음
+- 완료 조건이 없음
+- write scope를 잠글 수 없음
+
+다음 행동
+- `ambiguity-interview`로 전환
+- 첫 질문은 "이번 턴의 primary repo와 첫 issue를 무엇으로 고정할지"만 묻는다.
+```
+
+## Handoff
+
+route에 따라 아래처럼 넘긴다.
+
+- `대화`
+  - 답변만 제공하고 종료
+- `모호한 요청`
+  - 남아 있는 ambiguity signal 목록
+  - source of truth로 이미 해소한 내용
+  - 첫 interview blocker 한 개
+- `즉시 실행 가능한 작업`
+  - 대상 저장소
+  - 고정된 문제/범위/비범위
+  - write scope
+  - verification 초안
+  - 다음 단계: `issue-to-exec-plan`

--- a/.codex/skills/request-intake/SKILL.md
+++ b/.codex/skills/request-intake/SKILL.md
@@ -7,7 +7,7 @@ description: Use this skill when a new request arrives and you must classify it 
 
 ## Purpose
 
-새 요청을 intake 단계에서 `대화`, `모호한 요청`, `즉시 실행 가능한 작업` 중 하나로 고정하고, route에 맞는 다음 행동만 남긴다. 목표는 구현 아이디어를 늘리는 것이 아니라 "지금 실행을 시작해도 되는가"를 같은 기준으로 판정하는 것이다.
+새 요청을 intake 단계에서 `대화`, `모호한 요청`, `즉시 실행 가능한 작업` 중 하나로 고정하고, route에 맞는 다음 행동만 남긴다. 실행을 계속하지 않는 경우에는 terminal close-out인 `Rejected` reason도 함께 남긴다. 목표는 구현 아이디어를 늘리는 것이 아니라 "지금 실행을 시작해도 되는가"를 같은 기준으로 판정하는 것이다.
 
 ## Trigger
 
@@ -36,9 +36,10 @@ description: Use this skill when a new request arrives and you must classify it 
 
 - 산출물은 route decision summary다. 기본적으로 응답이나 작업 메모에 남긴다.
 - route별 다음 행동은 canonical policy를 그대로 따르되, skill output에는 아래 handoff만 남긴다.
-  - `대화`: 답변만 제공하고 종료
+  - `대화`: 답변만 제공하고 terminal close-out reason `conversation-only`를 남긴다.
   - `모호한 요청`: 남아 있는 ambiguity signal과 첫 interview blocker를 정리해 `ambiguity-interview`로 넘김
   - `즉시 실행 가능한 작업`: 문제, 범위, write scope, verification 요약을 정리해 `issue-to-exec-plan`으로 넘김
+- intake 단계에서 사용자가 취소했거나, 범위 밖 요청이거나, canonical source가 없어 실행을 계속하지 않기로 결정했다면 `Rejected` close-out reason을 함께 남긴다.
 
 ## Standard Commands
 
@@ -57,11 +58,13 @@ find docs/exec-plans/active docs/exec-plans/completed -maxdepth 1 -type f | sort
 
 - 어떤 source of truth 문서를 읽었는지
 - 최종 route: `대화`, `모호한 요청`, `즉시 실행 가능한 작업`
+- intake 단계에서 실행을 종료했다면 terminal close-out reason: `conversation-only`, `cancelled`, `out-of-scope`, `missing-canonical-source`
 - 남아 있는 ambiguity signal 또는 제거된 ambiguity 근거
 - 다음 행동
-  - `대화`: 답변만 제공하고 종료
+  - `대화`: 답변만 제공하고 `conversation-only`로 종료
   - `모호한 요청`: `ambiguity-interview`
   - `즉시 실행 가능한 작업`: `issue-to-exec-plan`
+  - intake에서 종료: `Rejected` close-out reason과 종료 근거
 - `즉시 실행 가능한 작업`이 아니면 왜 issue/exec plan을 만들지 않았는지
 
 ## Forbidden Shortcuts
@@ -106,7 +109,8 @@ Route: `모호한 요청`
 route에 따라 아래처럼 넘긴다.
 
 - `대화`
-  - 답변만 제공하고 종료
+  - 답변만 제공
+  - terminal close-out: `conversation-only`
 - `모호한 요청`
   - 남아 있는 ambiguity signal 목록
   - source of truth로 이미 해소한 내용
@@ -117,3 +121,7 @@ route에 따라 아래처럼 넘긴다.
   - write scope
   - verification 초안
   - 다음 단계: `issue-to-exec-plan`
+- `Rejected` close-out
+  - canonical close-out reason
+  - intake 단계에서 실행을 종료하는 근거
+  - issue, exec plan, 파일 편집을 시작하지 않았다는 점

--- a/docs/exec-plans/completed/2026-04-07-grw-s06-intake-ambiguity-skill-pack.md
+++ b/docs/exec-plans/completed/2026-04-07-grw-s06-intake-ambiguity-skill-pack.md
@@ -1,0 +1,138 @@
+# 2026-04-07-grw-s06-intake-ambiguity-skill-pack
+
+- Issue ID: `GRW-S06`
+- GitHub Issue: `#47`
+- Status: `Completed`
+- Repository: `git-ranker-workflow`
+- Branch Name: `feat/grw-s06-intake-ambiguity-skill-pack`
+- Task Slug: `2026-04-07-grw-s06-intake-ambiguity-skill-pack`
+- Primary Context Pack: `workflow-docs`
+- Verification Contract Profile: `workflow-docs`
+
+## Problem
+
+`GRW-12`에서 request routing과 ambiguity interview 정책은 source of truth로 고정됐지만, 실제 작업자가 같은 입력과 종료 조건으로 intake를 반복 수행하게 만드는 project-local skill은 아직 없다.
+
+이 상태에서는 같은 요청도 작업자별로 `대화`, `모호한 요청`, `즉시 실행 가능한 작업` 분류가 흔들릴 수 있고, ambiguity interview가 범위를 줄이는 절차가 아니라 구현 아이디어를 늘리는 절차로 drift할 수 있다.
+
+## Why Now
+
+`GRW-S06`은 Phase 2 skill pack의 첫 단계다. intake 절차를 먼저 반복 가능한 실행 레시피로 고정해야 이후 `context-pack-selection`, `boundary-check`, `verification-contract-runner`, `reviewer-handoff`도 같은 route taxonomy와 exit condition을 재사용할 수 있다.
+
+또한 workflow issue template과 `issue-to-exec-plan` skill이 이미 intake 필드와 exec plan handoff를 강제하고 있으므로, 이제는 그 입력을 어떻게 읽고 좁히고 종료시키는지를 skill로 연결해야 한다.
+
+## Scope
+
+- `.codex/skills/request-intake/SKILL.md` 작성
+- `.codex/skills/ambiguity-interview/SKILL.md` 작성
+- `.codex/skills/README.md`에 registry 및 추천 사용 순서 반영
+- `.codex/skills/authoring-rules.md`에 policy와 skill의 관리 경계 명시
+- `GRW-S06` active exec plan 작성과 완료 기록 정리
+
+## Non-scope
+
+- 신규 에이전트 런타임 구현
+- GitHub issue/exec plan 자동 생성 로직 추가
+- `GRW-S07`, `GRW-S08`, `GRW-S09` skill 작성
+- backend/frontend 앱 코드 변경
+
+## Write Scope
+
+- Primary repo: `git-ranker-workflow`
+- Allowed write paths:
+  - `.codex/skills/`
+  - `docs/exec-plans/`
+- Control-plane artifacts:
+  - `docs/exec-plans/active/2026-04-07-grw-s06-intake-ambiguity-skill-pack.md`
+  - `docs/exec-plans/completed/2026-04-07-grw-s06-intake-ambiguity-skill-pack.md`
+- Explicitly forbidden:
+  - sibling app repo code tree
+  - `docs/operations/`, `docs/architecture/`, `docs/product/`의 unrelated stable source of truth 수정
+- Network / external systems:
+  - GitHub issue metadata 확인과 생성
+- Escalation triggers:
+  - 없음
+
+## Outputs
+
+- `.codex/skills/request-intake/SKILL.md`
+- `.codex/skills/ambiguity-interview/SKILL.md`
+- `.codex/skills/README.md`
+- `docs/exec-plans/completed/2026-04-07-grw-s06-intake-ambiguity-skill-pack.md`
+
+## Working Decisions
+
+- `request-intake`는 route classification, ambiguity signal 확인, 다음 행동 결정을 담당하고 파일 편집이나 issue/exec plan 생성 자체를 소유하지 않는다.
+- `ambiguity-interview`는 source of truth 기반 blocker 축소, one-question-at-a-time interview, exit condition 정리를 담당한다.
+- `Planned`로 수렴한 뒤 GitHub issue와 exec plan 생성 handoff는 기존 `issue-to-exec-plan` skill을 재사용한다.
+- 두 skill 모두 `docs/operations/request-routing-policy.md`를 canonical source로 삼고 새 taxonomy를 발명하지 않는다.
+
+## Verification
+
+- `find .codex/skills -maxdepth 2 -type f | sort`
+  - 결과: `.codex/skills/request-intake/SKILL.md`, `.codex/skills/ambiguity-interview/SKILL.md`가 registry 문서와 함께 기대 경로에 생성된 것을 확인했다.
+- `sed -n '1,260p' .codex/skills/request-intake/SKILL.md`
+  - 결과: route classification, required evidence, forbidden shortcuts, example input/output, `issue-to-exec-plan` handoff가 포함된 것을 확인했다.
+- `sed -n '1,280p' .codex/skills/ambiguity-interview/SKILL.md`
+  - 결과: blocker 중심 질문 규칙, `Planned`/`Blocked`/`Rejected` exit summary, canonical close-out reason 참조, example interview output이 포함된 것을 확인했다.
+- `sed -n '1,220p' .codex/skills/authoring-rules.md`
+  - 결과: policy와 skill의 canonical ownership, policy 표 복사 금지, registry 관리 문서의 task ID 금지 규칙이 추가된 것을 확인했다.
+- `sed -n '1,220p' .codex/skills/README.md`
+  - 결과: skill registry에 `request-intake`, `ambiguity-interview`가 추가되고, canonical ownership section과 intake에서 planning으로 이어지는 추천 사용 순서가 반영되며 task ID가 제거된 것을 확인했다.
+- `sed -n '35,140p' .codex/skills/issue-to-exec-plan/SKILL.md` / `sed -n '75,130p' .codex/skills/parallel-work-split/SKILL.md`
+  - 결과: 샘플 명령, example input/output, 날짜/issue/slug 예시가 placeholder 기반으로 정리되어 특정 과거 work item을 재사용하지 않는 것을 확인했다.
+- `rg -n "request-intake|ambiguity-interview|Recommended Use|Rejected|즉시 실행 가능한 작업|모호한 요청" .codex/skills/README.md .codex/skills/request-intake/SKILL.md .codex/skills/ambiguity-interview/SKILL.md docs/operations/request-routing-policy.md`
+  - 결과: 새 skill 문서와 registry가 `request-routing-policy.md`의 route taxonomy, `Rejected` semantics, intake flow 용어와 함께 grep되는 것을 확인했다.
+- `rg -n "GRW-|GRB-|GRC-" .codex/skills/README.md .codex/skills/authoring-rules.md .codex/skills/request-intake/SKILL.md .codex/skills/ambiguity-interview/SKILL.md`
+  - 결과: 이번에 갱신한 skill registry, authoring rules, `GRW-S06` skill 문서에서는 task ID가 더 이상 남지 않는 것을 확인했다.
+- `gh issue view --repo alexization/git-ranker-workflow 47 --json body,title,number`
+  - 결과: GitHub Issue `#47` 본문이 template 섹션과 줄바꿈을 유지한 채 생성된 것을 확인했다.
+- 예시 요청 2건 수동 시뮬레이션 검토
+  - 결과: `request-intake`는 "랭킹 화면 좀 개선해줘"를 `모호한 요청`으로 분류하고 `ambiguity-interview` handoff를 남길 수 있었고, `ambiguity-interview`는 multi-repo 요청을 primary repo 질문 하나로 줄여 `Planned` summary 예시를 만들 수 있었다.
+- `git diff --check`
+  - 결과: whitespace 또는 conflict marker 문제 없이 통과했다.
+
+## Evidence
+
+문서형 skill 작업이므로 브라우저, 로그, 메트릭 artifact는 필수는 아니다. 대신 skill 본문, registry 갱신, 예시 요청 시뮬레이션, GitHub issue body render 확인 결과를 close-out에 남긴다.
+
+## Independent Review
+
+- Implementer: `Codex`
+- Reviewer: `Gemini CLI (gemini-2.5-flash)`
+- Reviewer Input:
+  - Exec plan: `docs/exec-plans/completed/2026-04-07-grw-s06-intake-ambiguity-skill-pack.md`
+  - Latest verification report: `passed`
+  - Diff summary: intake skill 2종 추가, skill registry/authoring rules의 policy-skill boundary 정리, 기존 skill 예시의 placeholder 일반화
+  - Source-of-truth update: `.codex/skills/README.md`, `.codex/skills/authoring-rules.md`, `.codex/skills/request-intake/SKILL.md`, `.codex/skills/ambiguity-interview/SKILL.md`, `.codex/skills/issue-to-exec-plan/SKILL.md`, `.codex/skills/parallel-work-split/SKILL.md`
+  - Remaining risks / skipped checks: 문서형 변경이므로 runtime/build 계열 conditional command 없음
+- Review Verdict: `approved`
+- Findings / Change Requests:
+  - blocking finding 없음
+  - non-blocking note였던 `api-contract-sync` 추천 순서 문구는 조건부 hook으로 다시 정리했다.
+- Evidence:
+  - reviewer는 request routing policy, workflow governance, dual-agent review policy, exec plan, changed skill 문서를 기준으로 scope drift, policy contradiction, verification mismatch 여부를 검토했고 `approved` verdict를 남겼다.
+
+## Risks or Blockers
+
+- `request-intake`가 `issue-to-exec-plan`과 책임이 겹치지 않도록, 새 skill 본문에서 issue/exec plan 생성은 handoff 이후 단계로 명시했다.
+- `ambiguity-interview`가 질문 수를 늘리는 방향으로 drift하지 않도록 one-question blocker 규칙과 두 라운드 뒤 stop condition을 본문에 명시했다.
+
+## Next Preconditions
+
+- `GRW-S07`: context pack 선택과 boundary 검토를 별도 skill로 고정
+- `GRW-S08`: verification/review handoff를 별도 skill로 고정
+
+## Docs Updated
+
+- `.codex/skills/request-intake/SKILL.md`
+- `.codex/skills/ambiguity-interview/SKILL.md`
+- `.codex/skills/README.md`
+- `.codex/skills/authoring-rules.md`
+- `.codex/skills/issue-to-exec-plan/SKILL.md`
+- `.codex/skills/parallel-work-split/SKILL.md`
+- `docs/exec-plans/completed/2026-04-07-grw-s06-intake-ambiguity-skill-pack.md`
+
+## Skill Consideration
+
+이번 Issue 자체가 intake skill pack을 추가하는 작업이다. 새 skill은 정책 문서를 대체하지 않고, route classification과 ambiguity interview를 같은 입력/출력/증거 규칙으로 재현하게 만드는 실행 레시피에 집중한다.

--- a/docs/exec-plans/completed/2026-04-07-grw-s06-intake-ambiguity-skill-pack.md
+++ b/docs/exec-plans/completed/2026-04-07-grw-s06-intake-ambiguity-skill-pack.md
@@ -72,7 +72,7 @@
 - `find .codex/skills -maxdepth 2 -type f | sort`
   - 결과: `.codex/skills/request-intake/SKILL.md`, `.codex/skills/ambiguity-interview/SKILL.md`가 registry 문서와 함께 기대 경로에 생성된 것을 확인했다.
 - `sed -n '1,260p' .codex/skills/request-intake/SKILL.md`
-  - 결과: route classification, required evidence, forbidden shortcuts, example input/output, `issue-to-exec-plan` handoff가 포함된 것을 확인했다.
+  - 결과: route classification, `Rejected` close-out reason 기록, required evidence, forbidden shortcuts, example input/output, `issue-to-exec-plan` handoff가 포함된 것을 확인했다.
 - `sed -n '1,280p' .codex/skills/ambiguity-interview/SKILL.md`
   - 결과: blocker 중심 질문 규칙, `Planned`/`Blocked`/`Rejected` exit summary, canonical close-out reason 참조, example interview output이 포함된 것을 확인했다.
 - `sed -n '1,220p' .codex/skills/authoring-rules.md`
@@ -91,6 +91,8 @@
   - 결과: `request-intake`는 "랭킹 화면 좀 개선해줘"를 `모호한 요청`으로 분류하고 `ambiguity-interview` handoff를 남길 수 있었고, `ambiguity-interview`는 multi-repo 요청을 primary repo 질문 하나로 줄여 `Planned` summary 예시를 만들 수 있었다.
 - `git diff --check`
   - 결과: whitespace 또는 conflict marker 문제 없이 통과했다.
+- `gh api repos/alexization/git-ranker-workflow/pulls/48/comments`
+  - 결과: automated review가 `request-intake`의 `Rejected` close-out 누락을 지적했고, skill output과 handoff에 terminal close-out reason 기록을 추가해 정책과 맞췄다.
 
 ## Evidence
 
@@ -111,7 +113,8 @@
   - blocking finding 없음
   - non-blocking note였던 `api-contract-sync` 추천 순서 문구는 조건부 hook으로 다시 정리했다.
 - Evidence:
-  - reviewer는 request routing policy, workflow governance, dual-agent review policy, exec plan, changed skill 문서를 기준으로 scope drift, policy contradiction, verification mismatch 여부를 검토했고 `approved` verdict를 남겼다.
+- reviewer는 request routing policy, workflow governance, dual-agent review policy, exec plan, changed skill 문서를 기준으로 scope drift, policy contradiction, verification mismatch 여부를 검토했고 `approved` verdict를 남겼다.
+- 후속 PR review에서 `request-intake`의 `Rejected` close-out 누락이 지적됐고, 이번 수정으로 `conversation-only`, `cancelled`, `out-of-scope`, `missing-canonical-source` 기록 규칙을 skill output에 반영했다.
 
 ## Risks or Blockers
 


### PR DESCRIPTION
## 1) Summary
- `.codex/skills/request-intake`와 `.codex/skills/ambiguity-interview`를 추가해 intake 단계의 route classification과 ambiguity narrowing 절차를 재사용 가능한 skill로 고정했습니다.
- `.codex/skills/README.md`, `.codex/skills/authoring-rules.md`, 기존 planning skill 예시를 정리해 policy/source-of-truth와 skill의 ownership 경계를 명확히 했습니다.
- `GRW-S07`, `GRW-S08` 이전에 intake 흐름을 먼저 skill로 고정해야 이후 context/boundary/review handoff도 같은 taxonomy를 재사용할 수 있습니다.

## 2) Linked Issue
- Closes #47
- Issue ID: `GRW-S06`
- 대상 저장소: `git-ranker-workflow`

## 3) Harness Contract
- Request Type: `즉시 실행 가능한 작업`
- Context / Source of Truth: `docs/operations/request-routing-policy.md`, `docs/operations/workflow-governance.md`, `docs/product/work-item-catalog.md`
- Write Scope: `.codex/skills/`, `docs/exec-plans/`
- Branch / Exec Plan: `feat/grw-s06-intake-ambiguity-skill-pack`, `docs/exec-plans/completed/2026-04-07-grw-s06-intake-ambiguity-skill-pack.md`

## 4) Scope
- In Scope: `request-intake`/`ambiguity-interview` skill 추가, skill registry 정리, authoring rules 경계 명시, planning skill 예시 placeholder 일반화, completed exec plan 기록
- Out of Scope: 신규 에이전트 런타임 구현, GitHub issue/exec plan 자동화, `GRW-S07`~`GRW-S09` skill 작성, backend/frontend 코드 변경

## 5) Outputs
- 변경된 문서 / 파일 / 디렉터리: `.codex/skills/request-intake/SKILL.md`, `.codex/skills/ambiguity-interview/SKILL.md`, `.codex/skills/README.md`, `.codex/skills/authoring-rules.md`, `.codex/skills/issue-to-exec-plan/SKILL.md`, `.codex/skills/parallel-work-split/SKILL.md`, `docs/exec-plans/completed/2026-04-07-grw-s06-intake-ambiguity-skill-pack.md`
- 후속 작업이 바로 참조할 산출물: intake/interview skill pack 본문, updated skill registry, completed exec plan close-out

## 6) Verification Contract

### Docs / Policy

#### Check Item
- Name: Skill 파일 생성과 required section 확인
- Command / Check: `find .codex/skills -maxdepth 2 -type f | sort`; `sed -n '1,260p' .codex/skills/request-intake/SKILL.md`; `sed -n '1,280p' .codex/skills/ambiguity-interview/SKILL.md`
- Final Status: `PASS`
- Evidence: `request-intake`, `ambiguity-interview`가 기대 경로에 생성됐고 route classification, blocker interview, handoff, forbidden shortcut, example input/output 섹션을 포함합니다.
- Failure / Exception: `-`

#### Check Item
- Name: Registry와 authoring boundary 정렬
- Command / Check: `sed -n '1,220p' .codex/skills/README.md`; `sed -n '1,220p' .codex/skills/authoring-rules.md`; `rg -n "request-intake|ambiguity-interview|Recommended Use|Rejected|즉시 실행 가능한 작업|모호한 요청" .codex/skills/README.md .codex/skills/request-intake/SKILL.md .codex/skills/ambiguity-interview/SKILL.md docs/operations/request-routing-policy.md`
- Final Status: `PASS`
- Evidence: registry에 새 skill과 추천 사용 순서가 반영됐고, authoring rules에 policy/skill boundary와 canonical ownership 규칙이 추가됐으며 route taxonomy가 canonical policy와 일치합니다.
- Failure / Exception: `-`

#### Check Item
- Name: Placeholder 예시와 task ID hygiene 확인
- Command / Check: `sed -n '35,140p' .codex/skills/issue-to-exec-plan/SKILL.md`; `sed -n '75,130p' .codex/skills/parallel-work-split/SKILL.md`; `rg -n "GRW-|GRB-|GRC-" .codex/skills/README.md .codex/skills/authoring-rules.md .codex/skills/request-intake/SKILL.md .codex/skills/ambiguity-interview/SKILL.md`; `git diff --check`
- Final Status: `PASS`
- Evidence: planning skill 예시가 placeholder 기반으로 일반화됐고, 새 skill/registry/management 문서에는 task ID가 남지 않으며 whitespace 문제도 없습니다.
- Failure / Exception: `-`

### Type / Lint / Test / Build

#### Check Item
- Name: Runtime / build contract
- Command / Check: `N/A (docs-only change)`
- Final Status: `N/A`
- Evidence: 이번 PR은 skill/documentation 변경만 포함하며 실행 코드나 build 대상 모듈을 수정하지 않았습니다.
- Failure / Exception: `-`

### Manual Check

#### Check Item
- Name: Example request simulation
- Command / Check: 예시 요청 2건 수동 시뮬레이션 검토
- Final Status: `PASS`
- Evidence: `request-intake`는 "랭킹 화면 좀 개선해줘"를 `모호한 요청`으로 분류해 `ambiguity-interview` handoff를 남길 수 있었고, `ambiguity-interview`는 multi-repo 요청을 primary repo 질문 하나로 줄이는 `Planned` 예시를 재현했습니다.
- Failure / Exception: `-`

### Other Task-Specific Contract

#### Check Item
- Name: GitHub issue body render 확인
- Command / Check: `gh issue view --repo alexization/git-ranker-workflow 47 --json body,title,number`
- Final Status: `PASS`
- Evidence: GitHub Issue `#47`가 template 섹션과 줄바꿈을 유지한 채 생성돼 PR close-out이 연결될 기준 이슈가 준비돼 있음을 확인했습니다.
- Failure / Exception: `-`

## 7) Independent Review
- Implementer: `Codex`
- Reviewer: `Gemini CLI (gemini-2.5-flash)`
- Reviewer Input: Exec plan `docs/exec-plans/completed/2026-04-07-grw-s06-intake-ambiguity-skill-pack.md`; Latest verification report `passed`; Diff summary `intake skill 2종 추가, skill registry/authoring rules의 policy-skill boundary 정리, 기존 skill 예시의 placeholder 일반화`; Source-of-truth update `.codex/skills/README.md`, `.codex/skills/authoring-rules.md`, `.codex/skills/request-intake/SKILL.md`, `.codex/skills/ambiguity-interview/SKILL.md`, `.codex/skills/issue-to-exec-plan/SKILL.md`, `.codex/skills/parallel-work-split/SKILL.md`; Remaining risks / skipped checks `문서형 변경이므로 runtime/build 계열 conditional command 없음`
- Review Verdict: `approved`
- Findings / Change Requests: blocking finding 없음; non-blocking note였던 `api-contract-sync` 추천 순서 문구는 조건부 hook으로 재정리했습니다.

## 8) Source of Truth Update
- 업데이트한 문서: `.codex/skills/request-intake/SKILL.md`, `.codex/skills/ambiguity-interview/SKILL.md`, `.codex/skills/README.md`, `.codex/skills/authoring-rules.md`, `.codex/skills/issue-to-exec-plan/SKILL.md`, `.codex/skills/parallel-work-split/SKILL.md`, `docs/exec-plans/completed/2026-04-07-grw-s06-intake-ambiguity-skill-pack.md`
- 업데이트하지 않은 문서와 사유: `docs/operations/request-routing-policy.md`, `docs/operations/workflow-governance.md`, `docs/product/work-item-catalog.md`는 canonical rule 변경이 아니라 existing rule을 skill로 operationalize하는 작업이라 본문 수정이 필요하지 않았습니다.

## 9) Feedback / Guardrail Follow-up
- 이번 작업에서 실제로 발생한 실패 / 예외 / 취약 지점: 문서 검토 중 `api-contract-sync` 추천 순서 문구와 registry의 task ID 추적 방식이 source-of-truth ownership과 충돌할 수 있어 skill management 문구를 정리했습니다.
- 새 guardrail 후보: 별도 신규 guardrail은 없음. 이번 PR 자체가 `request-intake`와 `ambiguity-interview` skill을 추가해 intake drift를 줄이는 guardrail 자산입니다.
- 후속 Issue 또는 TODO: `GRW-S07` context-pack/boundary skill pack, `GRW-S08` verification/review-loop skill pack

## 10) Risks and Rollback
- Risks: future policy 변경 시 skill 문서가 같이 갱신되지 않으면 intake taxonomy나 ownership boundary가 다시 drift할 수 있습니다.
- Rollback Plan: `git revert a36620c`로 skill pack 및 registry/exec plan 변경을 한 번에 되돌립니다.

## 11) Checklist
- [x] 연결된 Issue가 있다
- [x] Scope / Out of Scope가 적혀 있다
- [x] Write Scope가 적혀 있다
- [x] Verification 최종 상태와 예외가 기입되어 있다
- [x] Implementer와 Reviewer가 분리되어 있다
- [x] Source of Truth 반영 여부가 적혀 있다
- [x] Feedback 또는 후속 guardrail 후보가 적혀 있다
