### PR TITLE
docs: same-model reviewer pool 기본값 정렬

### DIFF
--- a/docs/architecture/harness-system-map.md
+++ b/docs/architecture/harness-system-map.md
@@ -28,7 +28,7 @@
 | Context Pack | task type에 맞는 최소 문서와 write scope를 고정한다. | exec plan, task type, source docs | bounded context pack |
 | Implementer | 허용된 저장소와 파일 범위 안에서 변경을 만든다. | context pack, exec plan | diff, change notes |
 | Verification | 명시된 verification contract를 실행하고 pass/fail을 기록한다. | diff, verification contract | verification report |
-| Reviewer | 구현과 분리된 관점으로 diff와 검증 결과를 검토한다. | diff, verification report, exec plan | review verdict |
+| Reviewer | 구현과 분리된 단일 reviewer 또는 session-isolated reviewer pool 관점으로 diff와 검증 결과를 검토한다. 필요 시 role-prompted reviewer pool finding을 집계해 final review verdict를 남긴다. | diff, verification report, exec plan | review verdict, aggregated findings |
 | Feedback | 실패와 취약 지점을 guardrail 후보로 분류하고 close-out을 남긴다. | review verdict, failure notes, exec plan | feedback entry, next follow-up |
 
 ## Canonical Artifacts
@@ -103,6 +103,7 @@
 
 - Implementer는 자기 결과를 최종 승인할 수 없다.
 - Reviewer는 diff만이 아니라 verification report와 exec plan을 함께 읽어야 한다.
+- reviewer가 같은 base model을 쓰더라도 implementer와 세션, 컨텍스트, 역할 프롬프트, output ownership이 분리돼 있어야 한다.
 - verification이 끝나기 전에는 review verdict를 final로 선언할 수 없다.
 - feedback 단계는 성공 경로와 실패 경로 모두에 필요하다. 성공 시에는 `no new guardrail`도 하나의 명시적 판단으로 남긴다.
 - task type별 세부 정책은 후속 Issue가 확장하더라도, `Router -> Interview -> Context Pack -> Implementer -> Verification -> Reviewer -> Feedback` 순서는 바꾸지 않는다.

--- a/docs/exec-plans/completed/2026-04-07-grw-21-same-model-reviewer-pool.md
+++ b/docs/exec-plans/completed/2026-04-07-grw-21-same-model-reviewer-pool.md
@@ -1,0 +1,148 @@
+# 2026-04-07-grw-21-same-model-reviewer-pool
+
+- Issue ID: `GRW-21`
+- GitHub Issue: `#50`
+- Status: `Completed`
+- Repository: `git-ranker-workflow`
+- Branch Name: `feat/grw-21-same-model-reviewer-pool`
+- Task Slug: `2026-04-07-grw-21-same-model-reviewer-pool`
+
+## Problem
+
+현재 `dual-agent review` 정책은 implementer와 reviewer를 분리해야 한다는 원칙까지는 고정했지만, 외부 reviewer runtime이 MCP timeout에 취약할 때 어떤 구조를 기본값으로 써야 하는지는 잠겨 있지 않았다.
+
+이 공백이 남아 있으면 independent review가 환경 실패에 묶여 실행되지 않거나, implementer가 임시로 reviewer 역할까지 겸하는 self-approval drift가 생길 수 있다. 같은 base model을 쓰더라도 세션, 컨텍스트, 역할 프롬프트, output ownership을 분리한 reviewer pool을 공식 runtime으로 인정해야 review stage가 실제로 운영된다.
+
+## Why Now
+
+사용자는 이미 implementer와 reviewer를 worker로 분리하려 했고, 현재 병목은 review quality 기준이 아니라 외부 reviewer runtime의 timeout 실패였다. 따라서 하네스는 "다른 모델"보다 "독립된 세션과 컨텍스트를 가진 reviewer"를 핵심 통제로 다시 정의해야 했다.
+
+현재 Codex 환경은 sub-agent 세션을 제공하므로, 같은 모델을 쓰더라도 세션 격리와 역할 프롬프트 분리만 지키면 reviewer pool을 바로 운영할 수 있다. 이 구조를 source of truth에 반영해야 이후 review handoff와 pilot issue도 같은 기본값을 따른다.
+
+## Scope
+
+- same-model multi-agent reviewer pool 허용 조건을 정의한다.
+- reviewer role taxonomy와 prompt/input boundary를 정의한다.
+- multi-reviewer verdict aggregation과 close-out 규칙을 정의한다.
+- 관련 architecture/operations/product hook을 같은 의미로 정렬한다.
+- 이번 작업 자체를 Codex sub-agent independent review evidence로 close-out한다.
+
+## Non-scope
+
+- 외부 MCP timeout 인프라 자체의 수정
+- backend/frontend 앱 코드 변경
+- 완전 자동 PR review bot 구현
+- verification contract 전면 재설계
+- `.codex/skills/` 신규 skill 작성
+
+## Write Scope
+
+- Primary repo: `git-ranker-workflow`
+- Allowed write paths:
+  - `docs/operations/`
+  - `docs/architecture/`
+  - `docs/product/`
+  - `docs/exec-plans/`
+- Control-plane artifacts:
+  - `docs/exec-plans/completed/2026-04-07-grw-21-same-model-reviewer-pool.md`
+  - `.artifacts/2026-04-07-grw-21-same-model-reviewer-pool/` 필요 시
+- Explicitly forbidden:
+  - sibling app repo code write
+  - 외부 reviewer runtime 구현 코드 추가
+  - scope 밖 stable source of truth mass update
+- Network / external systems:
+  - GitHub Issue create/view
+- Escalation triggers:
+  - 없음. 문서 작업 범위에서 처리했다.
+
+## Outputs
+
+- same-model reviewer pool semantics를 반영한 review policy
+- reviewer role prompt / input boundary / verdict aggregation rule
+- architecture/product/governance hook 갱신
+- `GRW-21` 실행 기록
+
+## Working Decisions
+
+- 이번 작업의 primary context pack은 `workflow-docs`다.
+- stable source of truth에는 특정 vendor명을 박지 않고 `same-model`, `session-isolated`, `role-prompted reviewer pool` vocabulary로 일반화한다.
+- review isolation의 핵심은 모델 종류가 아니라 세션, 컨텍스트, 역할 프롬프트, output ownership 분리다.
+- reviewer는 read-only 분석과 verdict만 담당하고, implementer는 findings를 받아 repair를 수행한다.
+- reviewer pool을 쓰더라도 최종 verdict vocabulary는 기존 `approved`, `changes-requested`, `blocked`를 유지한다.
+
+## Verification
+
+- `gh issue view --repo alexization/git-ranker-workflow 50 --json body,title,number`
+  - 결과: Issue `#50` 본문이 줄바꿈과 섹션을 유지한 채 생성된 것을 확인했다.
+- `sed -n '1,240p' docs/operations/dual-agent-review-policy.md`
+  - 결과: same-model reviewer pool 허용 조건, reviewer isolation model, reviewer pool mode, verdict aggregation, review evidence rule이 한 문서에 정리된 것을 확인했다.
+- `sed -n '70,170p' docs/operations/workflow-governance.md`
+  - 결과: evidence minimum, reviewer pool canonical verdict, reviewer handoff fan-out, same-model reviewer guardrail이 반영된 것을 확인했다.
+- `sed -n '287,310p' docs/operations/verification-contract-registry.md`
+  - 결과: reviewer handoff surface가 single reviewer와 reviewer pool 모두에 동일하게 적용되고, final verdict owner의 revision alignment 책임이 반영된 것을 확인했다.
+- `sed -n '20,120p' docs/architecture/harness-system-map.md`
+  - 결과: reviewer component와 role separation invariant가 reviewer pool aggregation과 output ownership 분리를 반영하는 것을 확인했다.
+- `sed -n '1,180p' docs/product/harness-roadmap.md`
+  - 결과: roadmap 목표, 고정 결정, phase order가 same-model reviewer pool 기본값을 반영하는 것을 확인했다.
+- `sed -n '100,180p' docs/product/work-item-catalog.md`
+  - 결과: `GRW-21` work item과 `GRW-S08`의 reviewer-handoff 기본 결정이 현재 정책과 일치하는 것을 확인했다.
+- `rg -n "same-model|session-isolated|reviewer pool|role-prompted|role prompt|verdict aggregation|output ownership|reviewer-coordinator" docs/operations/dual-agent-review-policy.md docs/operations/workflow-governance.md docs/operations/verification-contract-registry.md docs/architecture/harness-system-map.md docs/product/harness-roadmap.md docs/product/work-item-catalog.md`
+  - 결과: same-model reviewer pool, role-prompted reviewer, output ownership, aggregation vocabulary가 touched hook 전반에 일관되게 grep되는 것을 확인했다.
+- `git diff --check`
+  - 결과: whitespace 또는 patch formatting 오류가 없음을 확인했다.
+- independent review
+  - 결과: Codex sub-agent reviewer 둘이 각각 `scope-and-governance`, `verification-and-regression` role prompt로 diff와 exec plan을 검토했고 둘 다 `approved` verdict를 남겼다. blocking finding은 없었다.
+
+## Evidence
+
+문서 작업이므로 브라우저, 로그, 메트릭 artifact는 필수는 아니다. 대신 아래를 근거로 남긴다.
+
+- same-model reviewer pool policy 본문
+- architecture/product/governance hook 정렬 결과
+- GitHub Issue `#50` body render 확인 결과
+- Codex sub-agent independent review evidence
+
+## Independent Review
+
+- Implementer: `Codex`
+- Reviewer: `Pascal`
+- Additional Reviewers:
+  - `verification-and-regression`: `Volta`
+- Reviewer Roles / Prompt Focus: `scope-and-governance`, `verification-and-regression`
+- Reviewer Input:
+  - Exec plan: `docs/exec-plans/completed/2026-04-07-grw-21-same-model-reviewer-pool.md`
+  - Latest verification report: `passed`
+  - Diff summary: review policy, governance, verification handoff, architecture, roadmap, catalog에 same-model session-isolated reviewer pool semantics 반영
+  - Source-of-truth update: `docs/operations/dual-agent-review-policy.md`, `docs/operations/workflow-governance.md`, `docs/operations/verification-contract-registry.md`, `docs/architecture/harness-system-map.md`, `docs/product/harness-roadmap.md`, `docs/product/work-item-catalog.md`
+  - Remaining risks / skipped checks: reviewer-handoff skill은 아직 별도 구현되지 않았고, 이번 작업은 policy/source-of-truth 정렬까지만 수행
+- Review Verdict: `approved`
+- Findings / Change Requests:
+  - blocking finding 없음
+- Evidence:
+  - `Pascal`은 scope/governance 관점에서 scope/write-scope alignment가 유지되고, same-model reviewer pool wording이 self-approval drift를 허용하지 않는다고 확인했다.
+  - `Volta`는 verification/regression 관점에서 reviewer minimum context, handoff surface, aggregation rule이 기존 `approved | changes-requested | blocked` semantics를 깨지 않는다고 확인했다.
+
+## Risks or Blockers
+
+- same-model reviewer pool을 허용하더라도 실제 skill이나 운영 습관이 implementer/reviewer 세션을 섞어 쓰면 문서만으로 drift를 완전히 막을 수는 없다.
+- reviewer 수와 역할을 과도하게 고정하면 문서 작업처럼 위험 표면이 작은 이슈에도 review cost가 과도해질 수 있다.
+- future `reviewer-handoff` skill이 이번 policy를 thin layer로 재사용하지 않으면 runtime semantics가 다시 분기될 수 있다.
+
+## Next Preconditions
+
+- `GRW-S08`은 same-model reviewer pool fan-out과 aggregation을 thin layer skill로 재현해야 한다.
+- `GRW-18` pilot issue는 이번 policy와 evidence rule을 실제 close-out에 적용해야 한다.
+
+## Docs Updated
+
+- `docs/operations/dual-agent-review-policy.md`
+- `docs/operations/workflow-governance.md`
+- `docs/operations/verification-contract-registry.md`
+- `docs/architecture/harness-system-map.md`
+- `docs/product/harness-roadmap.md`
+- `docs/product/work-item-catalog.md`
+- `docs/exec-plans/completed/2026-04-07-grw-21-same-model-reviewer-pool.md`
+
+## Skill Consideration
+
+이번 작업은 skill을 직접 작성하는 단계는 아니다. 대신 후속 `reviewer-handoff` 또는 review-loop skill이 그대로 재사용할 수 있도록 same-model reviewer pool의 최소 규칙과 evidence를 source of truth로 먼저 고정했다.

--- a/docs/operations/dual-agent-review-policy.md
+++ b/docs/operations/dual-agent-review-policy.md
@@ -7,11 +7,15 @@
 ## Policy Invariants
 
 - implementer와 reviewer는 반드시 서로 다른 agent 또는 사람이어야 한다.
+- review의 독립성은 "다른 모델인가"보다 "다른 세션, 다른 컨텍스트, 다른 역할 프롬프트를 가졌는가"로 판단한다.
+- reviewer separation의 근거에는 output ownership 분리도 포함된다. reviewer verdict를 누가 최종 owner로 남기는지 evidence에서 추적 가능해야 한다.
 - review는 latest verification report의 overall status가 `passed`이고 reviewer handoff minimum이 채워진 뒤에만 시작할 수 있다.
 - PR 존재 여부는 review의 선행조건이 아니다. 기본 publish 흐름은 local diff와 verification 결과를 먼저 review하고, 그 verdict를 PR에 싣는 순서다.
 - reviewer는 diff만 보지 않고 exec plan, latest verification report, 남은 리스크를 함께 읽어야 한다.
 - reviewer는 현재 issue의 scope, write scope, verification contract, source of truth를 기준으로 판단한다. 새 목표 추가나 범위 확장은 review 단계에서 승인하지 않는다.
 - review evidence는 필수 산출물이다. verdict만 있고 reviewer input이나 finding 근거가 없으면 `Completed` 판정으로 보지 않는다.
+- same-model reviewer pool은 허용된다. 다만 각 reviewer가 implementer와 분리된 세션에서 시작하고 reviewer minimum context와 role prompt만 받아야 한다.
+- reviewer가 여러 명이면 최종 verdict는 pool aggregation 규칙으로 잠그고, implementer는 그 verdict를 임의로 완화할 수 없다.
 - future skill, template, checklist는 이 문서를 압축해서 재사용할 수 있지만, 이 문서를 대체하거나 override할 수는 없다.
 
 ## Role Split
@@ -19,7 +23,35 @@
 | Role | Must Do | Must Not Do | Required Output |
 | --- | --- | --- | --- |
 | Implementer | exec plan 범위 안에서 변경을 만들고 latest verification report를 준비한다. reviewer에게 diff summary, touched doc, 남은 리스크, conditional command 생략 사유를 넘긴다. review finding이 blocking이면 수정 후 관련 명령을 다시 실행한다. review verdict가 나오면 그 최신 결과를 PR body에 실어 publish한다. | 자기 결과를 최종 승인하지 않는다. review 전에 verification report 없이 완료를 주장하지 않는다. blocking finding을 non-blocking note로 축소하지 않는다. | diff, latest verification report, reviewer handoff input, publish-ready PR body |
-| Reviewer | implementer와 분리된 관점으로 scope, verification, diff, source-of-truth update, residual risk를 검토한다. finding을 blocking과 non-blocking으로 구분하고 verdict를 남긴다. | implementer 역할까지 겸해 자기 손으로 수정하며 review를 종료하지 않는다. verification이 비어 있는데 승인하지 않는다. 범위 밖 작업을 구두로 끼워 넣지 않는다. PR이 아직 없다는 이유로 review를 미루지 않는다. | review verdict, findings, review evidence |
+| Reviewer | implementer와 분리된 관점으로 scope, verification, diff, source-of-truth update, residual risk를 검토한다. finding을 blocking과 non-blocking으로 구분하고 verdict를 남긴다. reviewer pool이면 coordinator가 role별 finding을 집계해 final verdict를 남긴다. | implementer 역할까지 겸해 자기 손으로 수정하며 review를 종료하지 않는다. verification이 비어 있는데 승인하지 않는다. 범위 밖 작업을 구두로 끼워 넣지 않는다. PR이 아직 없다는 이유로 review를 미루지 않는다. implementer가 reviewer pool coordinator를 겸해 self-approval를 우회하지 않는다. | review verdict, findings, review evidence |
+
+## Reviewer Isolation Model
+
+- external reviewer model은 선택 사항이다. independent review의 핵심은 implementer와 reviewer가 서로 다른 세션과 컨텍스트에서 출발하는 것이다.
+- 같은 base model을 써도 reviewer가 implementer의 live session, draft reasoning, write ownership, output ownership을 공유하지 않으면 독립 reviewer로 인정할 수 있다.
+- reviewer input은 `Reviewer Minimum Context`와 role-specific prompt focus로 제한한다. implementer가 봤던 전체 탐색 문서 묶음, 미정 설계 메모, repair 중간 상태를 그대로 reviewer에게 넘기는 것은 기본값이 아니다.
+- reviewer는 read-only 분석과 verdict 산출을 맡는다. 파일 수정이나 repair 적용은 implementer가 다시 맡는다.
+
+## Reviewer Pool Mode
+
+- review는 단일 reviewer 또는 role-prompted reviewer pool로 수행할 수 있다.
+- 외부 reviewer runtime이 timeout이나 과도한 handoff 비용으로 불안정하면, 기본 fallback은 same-model session-isolated reviewer pool이다.
+- reviewer pool을 쓸 때도 공통 handoff surface는 `Reviewer Minimum Context`로 유지한다. 다만 각 reviewer는 자기 역할에 필요한 subset과 역할별 focus를 받을 수 있고, final verdict owner는 최소 컨텍스트 다섯 가지를 모두 추적 가능해야 한다.
+
+권장 role prompt 예시:
+
+| Reviewer Role | Primary Focus |
+| --- | --- |
+| `scope-and-governance` | exec plan scope, write scope, source-of-truth update, policy contradiction |
+| `verification-and-regression` | latest verification report, diff/report consistency, correctness, regression risk |
+| `security-and-reliability` | security, reliability, operational risk, follow-up 필요성 |
+
+추가 규칙:
+
+- role prompt는 집중 검토 영역을 좁히기 위한 것이지, reviewer minimum context를 생략하기 위한 핑계가 아니다.
+- 단순 문서 작업처럼 위험 표면이 작으면 단일 reviewer로 닫을 수 있다.
+- reviewer pool coordinator는 별도 reviewer이거나 reviewer 중 한 명일 수 있다. implementer는 결과를 기록할 수는 있어도 verdict를 새로 정하지 않는다.
+- reviewer pool coordinator는 reviewer 역할에 속한 owner여야 한다. implementer는 findings를 전달할 수는 있어도 aggregation owner가 되지 않는다.
 
 ## Reviewer Minimum Context
 
@@ -30,6 +62,8 @@ reviewer는 최소한 아래 입력을 받아야 한다.
 - touched diff summary와 touched file 또는 doc 목록
 - source-of-truth update 목록 또는 "업데이트 불필요" 사유
 - 남은 리스크, skipped conditional command, follow-up 필요 사항
+
+reviewer pool을 쓰더라도 위 다섯 가지가 공통 handoff surface라는 사실은 변하지 않는다. role prompt는 이 minimum 위에 덧붙는 추가 focus일 뿐이며, 역할별 reviewer는 필요한 subset만 읽을 수 있다.
 
 선택 입력:
 
@@ -54,6 +88,8 @@ reviewer는 아래 중 하나라도 있으면 verdict를 `blocked`로 둔다.
 
 이 순서를 건너뛰어도 되는 경우는 없다. reviewer는 최소 컨텍스트를 읽기 전에 verdict를 먼저 선언하지 않는다.
 
+reviewer pool에서는 각 reviewer가 자기 focus에 맞는 읽기 순서를 강조할 수 있지만, final verdict owner는 위 순서를 건너뛰지 않는다.
+
 ## Verdict Vocabulary
 
 | Verdict | Meaning | Required Consequence |
@@ -67,6 +103,17 @@ reviewer는 아래 중 하나라도 있으면 verdict를 `blocked`로 둔다.
 - non-blocking note는 `approved`와 함께 남길 수 있다.
 - implementer와 reviewer가 동일하면 기본 verdict는 `changes-requested`다. 별도 reviewer를 배정할 수 없는 상황까지 확인되면 `blocked`로 올린다.
 - reviewer는 `approved`를 주면서 blocking finding을 함께 남기지 않는다.
+
+## Verdict Aggregation
+
+reviewer pool을 쓸 때 overall verdict는 아래 규칙으로 잠근다.
+
+- 한 reviewer라도 `blocked`를 반환하면 overall verdict는 기본적으로 `blocked`다.
+- `blocked`가 없고 한 reviewer라도 blocking finding과 함께 `changes-requested`를 반환하면 overall verdict는 `changes-requested`다.
+- 모든 reviewer가 `approved`이거나 non-blocking note만 남기면 overall verdict는 `approved`다.
+- reviewer 간 해석이 충돌하면 더 엄격한 verdict를 우선하고, implementer가 그 차이를 임의 설명으로 상쇄하지 않는다.
+- final evidence에는 role별 finding 요약과 aggregated verdict 근거가 함께 남아야 한다.
+- finding aggregation이 불가능하거나 latest verification report와 reviewer finding의 revision이 맞지 않으면 overall verdict는 `blocked`다.
 
 ## Finding Classification
 
@@ -107,7 +154,10 @@ review verdict는 PR 본문, review comment, exec plan close-out 중 최소 한 
 ```md
 ## Independent Review
 - Implementer: `agent-or-name`
-- Reviewer: `agent-or-name`
+- Reviewer: `agent-or-name | reviewer-coordinator`
+- Additional Reviewers:
+  - `<role>: agent-or-name`
+- Reviewer Roles / Prompt Focus: `<optional when pool is used>`
 - Reviewer Input:
   - Exec plan: `docs/exec-plans/...`
   - Latest verification report: `passed`
@@ -124,6 +174,7 @@ review verdict는 PR 본문, review comment, exec plan close-out 중 최소 한 
 필수 규칙:
 
 - `Implementer`, `Reviewer`, `Review Verdict`는 항상 적는다.
+- reviewer pool을 썼다면 `Additional Reviewers` 또는 `Reviewer Roles / Prompt Focus`와 role별 finding 요약 또는 `no-blocking note`를 남긴다.
 - `Reviewer Input`에는 최소 컨텍스트 다섯 가지가 요약돼야 한다.
 - `approved`면 blocking finding이 없다는 점이 드러나야 한다.
 - `changes-requested`면 어떤 수정이 필요한지와 re-run 대상이 드러나야 한다.
@@ -133,6 +184,7 @@ review verdict는 PR 본문, review comment, exec plan close-out 중 최소 한 
 ## Draft Checklist
 
 - implementer와 reviewer가 분리돼 있는가
+- same-model reviewer를 썼다면 세션, 컨텍스트, 역할 프롬프트, output ownership 분리가 evidence에 드러나는가
 - exec plan의 scope, non-scope, write scope가 현재 diff와 일치하는가
 - latest verification report가 존재하고 overall status가 `passed`인가
 - skipped conditional command와 remaining risk가 reviewer input에 기록돼 있는가
@@ -143,4 +195,5 @@ review verdict는 PR 본문, review comment, exec plan close-out 중 최소 한 
 ## Relationship To Skills
 
 - future `reviewer-handoff` skill은 이 문서의 `Reviewer Minimum Context`, `Review Read Order`, `Review Evidence Rule`을 얇게 재사용한다.
+- future `reviewer-handoff` skill은 필요 시 same-model session-isolated reviewer pool에 동일한 minimum context를 fan-out하고, role prompt와 aggregation만 thin layer로 추가한다.
 - template와 checklist는 future skill 폴더 안에 둘 수 있지만, verdict vocabulary와 blocking 기준은 계속 이 문서가 canonical source다.

--- a/docs/operations/verification-contract-registry.md
+++ b/docs/operations/verification-contract-registry.md
@@ -296,4 +296,8 @@ reviewer에게 넘길 때는 최소한 아래 입력이 함께 있어야 한다.
 
 이 입력은 [dual-agent-review-policy.md](dual-agent-review-policy.md)의 `Reviewer Minimum Context`와 동일한 handoff surface다.
 
+single reviewer뿐 아니라 session-isolated reviewer pool을 쓸 때도 이 handoff surface를 그대로 fan-out한다. role prompt는 이 surface 위에 추가되는 focus일 뿐, minimum context를 없애거나 final verdict owner의 확인 책임을 덜어내는 근거가 아니다.
+
+각 reviewer는 자기 역할에 필요한 subset만 읽을 수 있지만, final verdict owner는 latest verification report와 reviewer finding을 같은 revision 기준으로 정렬해야 한다.
+
 이 입력이 비어 있으면 review 단계로 넘어간 것으로 보지 않는다.

--- a/docs/operations/workflow-governance.md
+++ b/docs/operations/workflow-governance.md
@@ -79,6 +79,7 @@
 - 명령 실행 결과 요약 또는 artifact 위치
 - verification report 최소 필드: contract profile, command별 status, 핵심 evidence, failure summary, next action
 - review evidence 최소 필드: implementer, reviewer, reviewer input, verdict, blocking finding 또는 no-blocking note
+- reviewer pool을 썼다면 final verdict owner와 추가 reviewer 또는 reviewer focus도 함께 남긴다
 - feedback evidence 최소 필드: stage, failure class, promotion decision, follow-up asset 또는 `no new guardrail` 이유, 핵심 evidence
 - 브라우저 증거: screenshot, trace, video
 - 로그 증거: LogQL 결과 또는 로그 요약
@@ -110,6 +111,7 @@
 - PR의 `6) Verification Contract`는 카테고리별 section 아래에 check별 block 형식으로 작성한다.
 - 성공한 검증은 최종 상태와 핵심 evidence만 짧게 적고, 실패, 재시도, 예외만 상세히 남긴다.
 - PR의 `7) Independent Review`는 [dual-agent-review-policy.md](dual-agent-review-policy.md)의 reviewer minimum context와 verdict vocabulary를 따른다.
+- independent review는 단일 reviewer 또는 session-isolated reviewer pool로 수행할 수 있다. 외부 reviewer runtime이 불안정하면 same-model reviewer pool을 기본 fallback으로 사용한다. reviewer pool을 쓰더라도 final verdict owner는 한 명이어야 하며, evidence block은 하나의 canonical verdict로 집계한다.
 - PR의 `9) Feedback / Guardrail Follow-up`는 [failure-to-guardrail-feedback-loop.md](failure-to-guardrail-feedback-loop.md)와 [guardrail-ledger-template.md](guardrail-ledger-template.md)의 vocabulary와 최소 필드를 따른다.
 - 생성 직후에는 `gh issue view --json body` 또는 `gh pr view --json body`로 본문이 예상한 줄바꿈과 섹션을 유지하는지 확인한다.
 - Issue template은 최소한 `문제`, `왜 지금`, `범위/비범위`, `write scope`, `context source`, `verification plan`, `open questions`를 포함해야 한다.
@@ -126,7 +128,7 @@
 2. 대상 저장소의 `develop` 최신 상태를 기준으로 worktree 또는 branch를 만든다.
 3. body file을 준비한 뒤 `gh issue create --body-file ...`로 대상 저장소 이슈를 만든다.
 4. 이슈 번호를 브랜치명과 exec plan에 연결한다.
-5. 작업 후 latest verification report를 만들고, reviewer minimum context를 준비한 뒤 independent review를 먼저 수행한다.
+5. 작업 후 latest verification report를 만들고, reviewer minimum context를 준비한 뒤 independent review를 먼저 수행한다. reviewer pool을 쓰면 공통 handoff surface를 각 reviewer에 fan-out하되, 역할별 focus에 맞는 subset만 줄 수 있고 final verdict owner 하나를 남긴다.
 6. PR body file에 검증 결과, independent review 결과, 문서 반영 여부, 남은 리스크를 먼저 채운다.
 7. 사용자가 draft를 명시적으로 요청했거나, scope-complete 전 blocker 공유가 필요하면 draft PR을 연다. 그렇지 않다면 `gh pr create --base develop --body-file ...`로 open PR을 연다.
 8. 생성 직후 `gh issue view --json body` 또는 `gh pr view --json body`로 본문 렌더링을 확인한다.
@@ -152,6 +154,8 @@
 - network나 escalation이 필요하면 목적과 범위를 exec plan 또는 최종 close-out에 남긴다.
 - verification failure가 나면 registry의 retry budget 안에서만 repair loop를 돌리고, budget 초과나 missing canonical source는 `Blocked` 또는 후속 planning으로 넘긴다.
 - review 단계에 들어가기 전 latest verification report와 reviewer minimum context를 준비한다.
+- reviewer pool을 쓰더라도 reviewer별로 다른 최소 입력을 임의 정의하지 않는다. 역할 프롬프트는 focus를 더할 수 있어도 minimum context를 줄일 수는 없다.
+- same-model reviewer를 쓰더라도 implementer와 reviewer의 세션, prompt, output ownership을 섞지 않는다.
 - 사용자가 다르게 요청하지 않았다면 independent review를 끝낸 뒤 PR을 publish한다.
 - source of truth 문서를 함께 업데이트하거나, 업데이트가 불필요한 이유를 남긴다.
 - 검증 명령과 최종 상태를 반드시 남기고, 실패나 예외가 있었다면 요약을 남긴다.
@@ -160,8 +164,8 @@
 - 실행 중 예상치 못한 dirty change가 있으면 되돌리지 말고 영향 여부만 확인한다.
 
 ## `.artifacts/` 보관 규칙
-
-작업 증거는 기본적으로 `.artifacts/<task-slug>/` 아래에 남긴다.
+업 증거는 기본적으로 `.artifacts/<task-slug>/`
+작아래에 남긴다.
 
 권장 구조:
 

--- a/docs/product/harness-roadmap.md
+++ b/docs/product/harness-roadmap.md
@@ -7,7 +7,7 @@
 1. 사용자 요청이 들어오면 먼저 `대화`, `모호한 요청`, `즉시 실행 가능한 작업`으로 라우팅한다.
 2. 실행 가능한 작업은 task type에 맞는 최소 컨텍스트와 명시적 write scope를 가진다.
 3. 구현 Agent는 결정론적 검증 명령을 통과하기 전까지 작업 완료를 주장할 수 없다.
-4. 코드 검토는 구현 Agent 자신이 아니라 별도의 review Agent가 수행한다.
+4. 코드 검토는 구현 Agent 자신이 아니라 별도의 review Agent 또는 session-isolated reviewer pool이 수행한다.
 5. 실패는 다음 문서, skill, 테스트, CI 가드레일로 축적된다.
 
 ## 이번 계획의 고정 결정
@@ -17,6 +17,7 @@
 - task type마다 읽을 문서와 수정 가능한 범위를 별도 context pack으로 고정한다.
 - 완료 판정은 `결정론적 검증 통과`와 `별도 review Agent 승인`이 함께 있어야 한다.
 - 구현 Agent와 review Agent는 역할을 분리한다.
+- review Agent는 model diversity보다 session/context separation을 우선한다. 필요하면 same-model session-isolated reviewer pool로 운영할 수 있다.
 - source of truth는 `workflow 중심`으로 유지하되, 앱 동작의 canonical source는 각 앱 저장소 코드와 테스트에 둔다.
 - 새 작업은 항상 exec plan으로 고정한 뒤 시작한다.
 - 사용자가 다르게 요청하지 않으면 PR은 independent review와 feedback evidence를 먼저 채운 뒤 open 상태로 publish한다.
@@ -31,7 +32,7 @@
 4. task type에 맞는 context pack만 Agent에 제공한다.
 5. Implementer Agent는 허용된 도구 경계 안에서만 작업한다.
 6. verification contract registry에 정의된 명령이 통과해야 다음 단계로 넘어간다.
-7. Reviewer Agent는 [../operations/dual-agent-review-policy.md](../operations/dual-agent-review-policy.md)에 따라 구현 diff와 검증 결과를 검토하고, 통과 또는 수정 요청을 결정한다.
+7. Reviewer Agent 또는 reviewer pool coordinator는 [../operations/dual-agent-review-policy.md](../operations/dual-agent-review-policy.md)에 따라 단일 reviewer 또는 role-prompted reviewer pool로 구현 diff와 검증 결과를 검토하고, 통과 또는 수정 요청을 결정한다.
 8. 실패한 작업은 [../operations/failure-to-guardrail-feedback-loop.md](../operations/failure-to-guardrail-feedback-loop.md)의 feedback ledger에 남기고 다음 가드레일 후보로 전환한다.
 
 ## 권장 실행 순서
@@ -47,19 +48,20 @@
 7. `GRW-15` verification contract registry와 repair loop 기준 정의
 8. `GRW-16` dual-agent review policy 정의
 9. `GRW-17` failure-to-guardrail feedback loop 정의
+10. `GRW-21` same-model reviewer pool 기본값 정렬
 
 ### Phase 2. Skills and Pilot
 
-10. `GRW-S06` intake/ambiguity skill pack
-11. `GRW-S07` context-pack/boundary skill pack
-12. `GRW-S08` verification/review-loop skill pack
-13. `GRW-S09` guardrail-hardening skill pack
-14. `GRW-18` workflow repo pilot issue로 새 흐름 1회 검증
+11. `GRW-S06` intake/ambiguity skill pack
+12. `GRW-S07` context-pack/boundary skill pack
+13. `GRW-S08` verification/review-loop skill pack
+14. `GRW-S09` guardrail-hardening skill pack
+15. `GRW-18` workflow repo pilot issue로 새 흐름 1회 검증
 
 ### Phase 3. Repo-Specific Contracts
 
-15. `GRB-04` backend verification contract 정규화
-16. `GRC-05` frontend verification contract 정규화
+16. `GRB-04` backend verification contract 정규화
+17. `GRC-05` frontend verification contract 정규화
 
 ## 바로 다음에 추천하는 작업
 

--- a/docs/product/work-item-catalog.md
+++ b/docs/product/work-item-catalog.md
@@ -110,6 +110,17 @@
 - 산출물: feedback loop policy, guardrail ledger template
 - 검증: 과거 실패 사례 2~3개를 분류해 ledger에 적합한지 확인
 
+### GRW-21. same-model reviewer pool 기본값 정렬
+
+- 저장소: `git-ranker-workflow`
+- 선행조건: `GRW-16`
+- 권장 write scope: `docs/operations`, `docs/architecture`, `docs/product`, `docs/exec-plans/`
+- 기본 결정: 독립 review의 핵심은 model diversity보다 session/context/prompt isolation이다. 외부 reviewer runtime이 불안정하면 same-model session-isolated reviewer pool을 기본 fallback으로 쓴다.
+- 핵심 작업: same-model reviewer pool 허용 조건, role prompt focus, reviewer minimum context fan-out, verdict aggregation 규칙을 source of truth에 반영한다.
+- 비범위: 외부 MCP timeout 자체의 인프라 수정, 자동 PR review bot 구현, backend/frontend 앱 코드 변경
+- 산출물: updated review policy와 architecture/product hook, `GRW-21` exec plan
+- 검증: role prompt, reviewer pool, verdict aggregation 관련 hook grep과 independent review evidence 확인
+
 ### GRW-18. workflow repo pilot issue로 새 흐름 1회 검증
 
 - 저장소: `git-ranker-workflow`
@@ -150,7 +161,7 @@
 - 저장소: `git-ranker-workflow`
 - 선행조건: `GRW-15`, `GRW-16`
 - 권장 write scope: `.codex/skills/` 하위만
-- 기본 결정: 구현 완료 선언보다 검증과 review handoff를 우선한다. 저장소별 명령은 contract registry가 canonical source다.
+- 기본 결정: 구현 완료 선언보다 검증과 review handoff를 우선한다. 저장소별 명령은 contract registry가 canonical source고, review runtime 기본값은 same-model session-isolated reviewer pool을 우선 재사용한다.
 - 핵심 작업: `verification-contract-runner`, `repair-loop-triage`, `reviewer-handoff` skill 작성
 - 비범위: 테스트 프레임워크 추가
 - 산출물: skill 문서 3개


### PR DESCRIPTION
## 1) Summary
- same-model `session-isolated reviewer pool`을 하네스의 기본 reviewer runtime fallback으로 문서화했습니다.
- reviewer separation을 모델 종류가 아니라 세션, 컨텍스트, 역할 프롬프트, output ownership 분리로 정의하고, reviewer pool의 final verdict owner와 aggregation 규칙을 고정했습니다.

## 2) Linked Issue
- Closes #50
- Issue ID: `GRW-21`
- 대상 저장소: `git-ranker-workflow`

## 3) Harness Contract
- Request Type: `policy/governance`
- Context / Source of Truth:
  - `docs/operations/dual-agent-review-policy.md`
  - `docs/operations/workflow-governance.md`
  - `docs/operations/verification-contract-registry.md`
  - `docs/architecture/harness-system-map.md`
  - `docs/product/harness-roadmap.md`
  - `docs/product/work-item-catalog.md`
- Write Scope:
  - `docs/operations/`
  - `docs/architecture/`
  - `docs/product/`
  - `docs/exec-plans/`
- Branch / Exec Plan:
  - `feat/grw-21-same-model-reviewer-pool`
  - `docs/exec-plans/completed/2026-04-07-grw-21-same-model-reviewer-pool.md`

## 4) Scope
- In Scope:
  - same-model reviewer pool 허용 조건 정의
  - reviewer role prompt / minimum context / verdict aggregation 규칙 정렬
  - architecture / governance / roadmap / catalog hook 정렬
- Out of Scope:
  - 외부 MCP timeout 인프라 수정
  - backend/frontend 앱 코드 변경
  - reviewer-handoff skill 구현

## 5) Outputs
- 변경된 문서 / 파일 / 디렉터리:
  - `docs/operations/dual-agent-review-policy.md`
  - `docs/operations/workflow-governance.md`
  - `docs/operations/verification-contract-registry.md`
  - `docs/architecture/harness-system-map.md`
  - `docs/product/harness-roadmap.md`
  - `docs/product/work-item-catalog.md`
  - `docs/exec-plans/completed/2026-04-07-grw-21-same-model-reviewer-pool.md`
- 후속 작업이 바로 참조할 산출물:
  - same-model reviewer pool canonical policy
  - `GRW-21` completed exec plan

## 6) Verification Contract

### Docs / Policy

#### Check Item
- Name: Policy review
- Command / Check: `sed -n '1,240p' docs/operations/dual-agent-review-policy.md`
- Final Status: `PASS`
- Evidence: same-model reviewer pool, output ownership separation, reviewer-coordinator, verdict aggregation 규칙 확인
- Failure / Exception:

#### Check Item
- Name: Governance review
- Command / Check: `sed -n '70,170p' docs/operations/workflow-governance.md`
- Final Status: `PASS`
- Evidence: reviewer pool evidence minimum, canonical verdict owner, handoff fan-out rule 확인
- Failure / Exception:

#### Check Item
- Name: Verification handoff review
- Command / Check: `sed -n '287,310p' docs/operations/verification-contract-registry.md`
- Final Status: `PASS`
- Evidence: shared handoff surface와 final verdict owner revision alignment 규칙 확인
- Failure / Exception:

#### Check Item
- Name: Hook alignment
- Command / Check: `rg -n "same-model|session-isolated|reviewer pool|role-prompted|role prompt|verdict aggregation|output ownership|reviewer-coordinator" docs/operations/dual-agent-review-policy.md docs/operations/workflow-governance.md docs/operations/verification-contract-registry.md docs/architecture/harness-system-map.md docs/product/harness-roadmap.md docs/product/work-item-catalog.md`
- Final Status: `PASS`
- Evidence: touched hook 전반에서 reviewer pool vocabulary가 일관되게 grep됨
- Failure / Exception:

#### Check Item
- Name: Diff formatting
- Command / Check: `git diff --check`
- Final Status: `PASS`
- Evidence: whitespace / patch formatting 오류 없음
- Failure / Exception:

### Type / Lint / Test / Build

#### Check Item
- Name: N/A
- Command / Check: 문서 작업
- Final Status: `N/A`
- Evidence:
- Failure / Exception:

### Manual Check

#### Check Item
- Name: Issue body render
- Command / Check: `gh issue view --repo alexization/git-ranker-workflow 50 --json body,title,number`
- Final Status: `PASS`
- Evidence: Issue `#50` 본문 줄바꿈과 섹션 유지 확인
- Failure / Exception:

### Other Task-Specific Contract

#### Check Item
- Name: Codex sub-agent independent review
- Command / Check: role-prompted reviewer pool 수동 검토
- Final Status: `PASS`
- Evidence: `Pascal`, `Volta` 두 reviewer 모두 `approved`
- Failure / Exception:

## 7) Independent Review
- Implementer: `Codex`
- Reviewer: `Pascal`
- Additional Reviewers:
  - `verification-and-regression`: `Volta`
- Reviewer Input:
  - Exec plan: `docs/exec-plans/completed/2026-04-07-grw-21-same-model-reviewer-pool.md`
  - Latest verification report: `passed`
  - Diff summary: review policy, governance, verification handoff, architecture, roadmap, catalog에 same-model session-isolated reviewer pool semantics 반영
  - Source-of-truth update: `docs/operations/dual-agent-review-policy.md`, `docs/operations/workflow-governance.md`, `docs/operations/verification-contract-registry.md`, `docs/architecture/harness-system-map.md`, `docs/product/harness-roadmap.md`, `docs/product/work-item-catalog.md`
  - Remaining risks / skipped checks: `reviewer-handoff` skill 구현은 후속 범위
- Review Verdict: `approved`
- Findings / Change Requests:
  - blocking finding 없음

## 8) Source of Truth Update
- 업데이트한 문서:
  - `docs/operations/dual-agent-review-policy.md`
  - `docs/operations/workflow-governance.md`
  - `docs/operations/verification-contract-registry.md`
  - `docs/architecture/harness-system-map.md`
  - `docs/product/harness-roadmap.md`
  - `docs/product/work-item-catalog.md`
  - `docs/exec-plans/completed/2026-04-07-grw-21-same-model-reviewer-pool.md`
- 업데이트하지 않은 문서와 사유:
  - `.codex/skills/`는 후속 `GRW-S08` 범위라 이번 PR에서는 문서 hook만 남김

## 9) Feedback / Guardrail Follow-up
- 이번 작업에서 실제로 발생한 실패 / 예외 / 취약 지점:
  - 외부 reviewer runtime timeout이 반복되어 independent review default를 같은 모델의 session-isolated reviewer pool로 재정의할 필요가 있었음
- 새 guardrail 후보:
  - 없음. 이번 source-of-truth 정렬 자체가 guardrail 추가에 해당함
- 후속 Issue 또는 TODO:
  - `GRW-S08`에서 reviewer-handoff thin layer 구현
  - `GRW-18`에서 pilot issue로 실제 운영 검증

## 10) Risks and Rollback
- Risks:
  - same-model reviewer pool을 허용해도 실제 운영에서 세션 분리 discipline이 흐려지면 self-approval drift 위험이 남음
  - reviewer role을 과도하게 늘리면 작은 문서 작업에도 review cost가 커질 수 있음
- Rollback Plan:
  - 이 PR revert
  - reviewer runtime 기본값을 single reviewer semantics로 되돌림

## 11) Checklist
- [x] 연결된 Issue가 있다
- [x] Scope / Out of Scope가 적혀 있다
- [x] Write Scope가 적혀 있다
- [x] Verification 최종 상태와 예외가 기입되어 있다
- [x] Implementer와 Reviewer가 분리되어 있다
- [x] Source of Truth 반영 여부가 적혀 있다
- [x] Feedback 또는 후속 guardrail 후보가 적혀 있다