### PR TITLE
[GRW-23] continuous quality feedback loop 정렬

### DIFF
--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -88,6 +88,7 @@
 - `reviewer-handoff`: reviewer minimum context를 reviewer pool에 fan-out하고 aggregated review evidence를 남길 때 사용
 - `guardrail-ledger-update`: latest verification/review 결과를 guardrail ledger entry와 feedback close-out evidence로 정리할 때 사용
 - `failure-to-policy`: normalized failure를 가장 작은 guardrail asset으로 승격하거나 `no-new-guardrail` 예외를 판단할 때 사용
+- `quality-sweep-triage`: periodic 또는 targeted quality sweep 결과를 cleanup candidate, guardrail follow-up, repair-now로 분류할 때 사용
 - `red`: failing test file 하나만 남기는 TDD red turn
 - `green`: test 수정 없이 최소 구현으로 green을 만드는 턴
 - `refactor`: green 유지 하에 구조를 정리하는 refactor 턴
@@ -122,6 +123,7 @@ close-out이 `Rejected`이거나 route가 `대화`로 끝나면 issue, exec plan
 3. `reviewer-handoff` once latest verification report is `passed`
 4. `guardrail-ledger-update` once latest verification and review outcomes are fixed
 5. `failure-to-policy` when feedback close-out must choose a guardrail promotion target or `no-new-guardrail`
+6. `quality-sweep-triage` when periodic or targeted quality scan is in scope
 
 `api-contract-sync`의 canonical backend contract는 `git-ranker/docs/openapi/openapi.json`이다. workflow는 canonical spec을 복제해 소유하지 않고, sync 절차와 evidence를 관리한다.
 

--- a/.codex/skills/quality-sweep-triage/SKILL.md
+++ b/.codex/skills/quality-sweep-triage/SKILL.md
@@ -40,6 +40,7 @@ quality sweep signal을 `repair-now`, `cleanup-pr-candidate`, `guardrail-follow-
   - scan scope
   - detection surface
   - signal class
+  - trigger signal
   - severity
   - selected disposition
   - follow-up asset / issue / PR
@@ -64,6 +65,7 @@ rg -n "lint|duplicate|unused|quality sweep|cleanup" docs/exec-plans docs/operati
 - trigger mode와 source artifact
 - bounded scan scope
 - signal class와 그 이유
+- trigger signal
 - detection surface
 - severity 판단 근거
 - selected disposition과 selection rule 근거
@@ -102,6 +104,7 @@ Sweep Decision
 - Scan scope: `src/features/ranking`
 - Detection surface: lint warning summary, reviewer note
 - Signal class: `unused-code-drift`
+- Trigger signal: ranking helper 2개가 route refactor 이후 호출되지 않는다.
 - Severity: `non-blocking`
 - Disposition: `cleanup-pr-candidate`
 - Follow-up asset / issue / PR: cleanup issue 초안

--- a/.codex/skills/quality-sweep-triage/SKILL.md
+++ b/.codex/skills/quality-sweep-triage/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: quality-sweep-triage
+description: Use this skill when a periodic or targeted quality sweep must classify coding-rule drift, duplication, or unused code into cleanup candidates, guardrail follow-up, or repair-now.
+---
+
+# Quality Sweep Triage
+
+## Purpose
+
+quality sweep signal을 `repair-now`, `cleanup-pr-candidate`, `guardrail-follow-up`, `no-action` 중 하나로 좁히고, 다음 work item이 바로 시작될 수 있게 report와 handoff를 고정한다. 목표는 "정리할 것 같음" 수준의 메모를 남기는 것이 아니라, bounded quality drift를 evidence와 next action까지 포함한 candidate로 바꾸는 것이다.
+
+## Trigger
+
+- completed issue/PR 뒤에 `post-closeout` quality sweep을 해야 한다.
+- repo maintainer나 runtime이 `scheduled` sweep 결과를 넘겼다.
+- reviewer note나 반복 finding 때문에 `targeted` sweep을 해야 한다.
+- lint drift, duplication, unused code signal을 cleanup candidate로 분리할지 판단해야 한다.
+
+## Inputs and Preconditions
+
+- `docs/operations/continuous-quality-feedback-loop.md`를 먼저 읽는다.
+- `docs/operations/quality-sweep-report-template.md`를 먼저 읽는다.
+- signal이 나온 source task, PR, baseline, reviewer note, 또는 repo-specific detector output이 있어야 한다.
+- 대상 저장소와 scan scope를 한 문장으로 적을 수 있어야 한다.
+- blocking regression 가능성이 보이면 `docs/operations/failure-to-guardrail-feedback-loop.md`와 repair/bug follow-up 가능성을 함께 본다.
+
+## Canonical Boundary
+
+- trigger mode, signal class, disposition vocabulary, cleanup handoff minimum은 `docs/operations/continuous-quality-feedback-loop.md`가 canonical source다.
+- report field shape는 `docs/operations/quality-sweep-report-template.md`가 canonical source다.
+- repeated detector gap을 guardrail 자산으로 승격하는 규칙은 `docs/operations/failure-to-guardrail-feedback-loop.md`를 따른다.
+- 이 skill은 현재 signal을 policy에 대입해 next action만 좁힌다. 새 signal class나 disposition을 만들지 않는다.
+
+## Output and Artifact Location
+
+- 산출물은 quality sweep report에 복사 가능한 triage summary다.
+- 최소 아래를 남긴다.
+  - trigger mode
+  - source repo와 source task/PR/baseline
+  - scan scope
+  - detection surface
+  - signal class
+  - severity
+  - selected disposition
+  - follow-up asset / issue / PR
+  - owner / next action
+  - 핵심 evidence
+
+## Standard Commands
+
+반복적으로 확인하는 기본 명령 예시:
+
+```bash
+sed -n '1,260p' docs/operations/continuous-quality-feedback-loop.md
+sed -n '1,220p' docs/operations/quality-sweep-report-template.md
+sed -n '1,260p' docs/exec-plans/completed/<plan>.md
+rg -n "lint|duplicate|unused|quality sweep|cleanup" docs/exec-plans docs/operations
+```
+
+핵심은 detector output이나 review note를 "새 cleanup work item으로 바로 넘길 수 있는가" 기준으로 좁히는 것이다. evidence 없이 후보를 늘리지 않는다.
+
+## Required Evidence
+
+- trigger mode와 source artifact
+- bounded scan scope
+- signal class와 그 이유
+- detection surface
+- severity 판단 근거
+- selected disposition과 selection rule 근거
+- cleanup candidate 또는 guardrail follow-up의 next owner
+- `no-action`이면 explicit rationale
+
+## Forbidden Shortcuts
+
+- blocking regression을 `cleanup-pr-candidate`로 축소하지 않는다.
+- original issue completion verdict를 quality sweep note 하나로 뒤집지 않는다.
+- 여러 signal class를 한 report에 섞지 않는다.
+- evidence 없이 "중복", "unused" 같은 추정만 남기지 않는다.
+- cleanup candidate를 current issue diff에 슬쩍 섞어 넣지 않는다.
+- repo-specific detector가 없는데 workflow 문서가 임의의 도구를 canonical로 발명하지 않는다.
+
+## Parallel Ownership Rule
+
+- quality sweep report의 final owner는 한 명이어야 한다.
+- 여러 reviewer나 maintainer가 signal을 제보할 수는 있지만, disposition과 next action 통합은 current sweep owner가 맡는다.
+- cleanup candidate가 여러 개면 report와 follow-up owner를 candidate별로 분리한다.
+
+## Example Input
+
+- Trigger mode: `post-closeout`
+- Source repo: `git-ranker-client`
+- Scan scope: `src/features/ranking`
+- Signal: ranking helper 2개가 route refactor 이후 호출되지 않는다.
+- Evidence: lint warning과 reviewer note
+
+## Example Output
+
+```md
+Sweep Decision
+- Trigger mode: `post-closeout`
+- Source repo: `git-ranker-client`
+- Scan scope: `src/features/ranking`
+- Detection surface: lint warning summary, reviewer note
+- Signal class: `unused-code-drift`
+- Severity: `non-blocking`
+- Disposition: `cleanup-pr-candidate`
+- Follow-up asset / issue / PR: cleanup issue 초안
+- Owner / next action: `request-intake`로 새 cleanup issue를 시작한다.
+- Evidence: unused helper 이름, grep path inventory, reviewer note
+```
+
+## Handoff
+
+결정이 끝나면 아래처럼 넘긴다.
+
+- `cleanup-pr-candidate`
+  - 대상 저장소
+  - bounded scan scope
+  - 핵심 evidence
+  - non-scope
+  - next step: `request-intake` -> `issue-to-exec-plan`
+- `guardrail-follow-up`
+  - repeated detector gap 또는 missing gate 근거
+  - next step: `failure-to-policy`
+- `repair-now`
+  - blocking signal
+  - next step: 새 bug/repair issue 또는 repair owner handoff
+- `no-action`
+  - explicit rationale
+  - duplicate or false-positive note

--- a/docs/architecture/harness-system-map.md
+++ b/docs/architecture/harness-system-map.md
@@ -11,7 +11,7 @@
 3. 도구 경계와 write scope 통제
 4. 결정론적 검증
 5. 구현 Agent와 review Agent 분리
-6. 실패의 가드레일화
+6. 실패의 가드레일화와 quality drift의 cleanup 분리
 
 ## Planning Boundary
 
@@ -29,7 +29,7 @@
 | Implementer | 허용된 저장소와 파일 범위 안에서 변경을 만든다. | context pack, exec plan | diff, change notes |
 | Verification | 명시된 verification contract를 실행하고 pass/fail을 기록한다. | diff, verification contract | verification report |
 | Reviewer | 구현과 분리된 session-isolated sub-agent reviewer pool이 역할별로 diff와 검증 결과를 검토하고, reviewer coordinator가 finding을 집계해 final review verdict를 남긴다. | diff, verification report, exec plan | review verdict, aggregated findings |
-| Feedback | 실패와 취약 지점을 guardrail 후보로 분류하고 close-out을 남긴다. | review verdict, failure notes, exec plan | feedback entry, next follow-up |
+| Feedback | 실패와 quality drift를 guardrail 후보 또는 cleanup candidate로 분류하고 close-out을 남긴다. | review verdict, failure notes, exec plan, quality sweep signal | feedback entry, quality sweep report, next follow-up |
 
 ## Canonical Artifacts
 
@@ -41,6 +41,7 @@
 | Verification report | 실행 명령, 최종 상태, 핵심 evidence, 실패/예외 요약 | exec plan, verification artifact |
 | Review verdict | reviewer 승인 또는 수정 요청 | review comment, exec plan 요약 |
 | Feedback entry | 반복 실패와 guardrail 승격 여부 | exec plan, 후속 policy 또는 ledger |
+| Quality sweep report | lint drift, duplication, unused code 같은 non-blocking quality signal과 cleanup handoff | exec plan, sweep artifact, 후속 issue/PR |
 
 ## Canonical State Machine
 
@@ -90,13 +91,14 @@
 | Implementer | 허용 write scope 안에서 목표 산출물을 만든다. | scope drift, 무단 cross-repo 변경, 불명확한 요구사항이 발생한다. | `Blocked`로 전환하고 범위를 재정의한다. |
 | Verification | 모든 필수 검증 명령이 통과하고 증거가 남는다. | 명령 실패, 환경 부족, 증거 누락이 있다. | `Repairing` 또는 `Blocked`로 전환한다. |
 | Reviewer | reviewer가 diff, verification report, 남은 리스크를 기준으로 승인한다. | blocking finding, self-approval 시도, 검증과 diff 불일치가 있다. | `Repairing`으로 되돌린다. |
-| Feedback | 실패 분류 또는 `no new guardrail` 판단이 기록됐다. | close-out과 후속 guardrail 판단이 비어 있다. | `Feedback Pending`에 머문다. |
+| Feedback | 실패 분류, `no new guardrail`, 또는 quality sweep disposition이 기록됐다. | close-out과 후속 guardrail/cleanup 판단이 비어 있다. | `Feedback Pending`에 머문다. |
 
 ## Stop Conditions
 
 - `Rejected`: 대화성 요청, 범위 밖 요청, 사용자 취소처럼 작업 자체를 진행하지 않는 경우다.
 - `Blocked`: 선행조건 부족, 외부 의존성, 권한 문제, canonical source 부재로 현재 이슈 안에서 더 진행할 수 없는 경우다.
 - `Completed`: verification 통과, reviewer 승인, feedback close-out이 모두 끝난 경우다.
+- `Completed`는 terminal state지만, post-closeout quality sweep이 필요하면 새 `Received` work item을 시작할 수 있다. 이 경우 original issue를 다시 열지 않는다.
 - `Repairing`은 terminal state가 아니다. 반복 실패가 누적되면 verification contract registry와 feedback/guardrail policy에 정의된 retry budget 기준에 따라 `Blocked` 또는 후속 planning으로 넘긴다.
 
 ## Role Separation Invariants
@@ -106,6 +108,7 @@
 - reviewer sub-agent들은 implementer와 세션, 컨텍스트, 역할 프롬프트, output ownership이 분리돼 있어야 한다.
 - verification이 끝나기 전에는 review verdict를 final로 선언할 수 없다.
 - feedback 단계는 성공 경로와 실패 경로 모두에 필요하다. 성공 시에는 `no new guardrail`도 하나의 명시적 판단으로 남긴다.
+- non-blocking quality drift는 original issue의 completion verdict를 뒤집지 않고, separate cleanup issue/PR candidate로 분리한다.
 - task type별 세부 정책은 후속 Issue가 확장하더라도, `Router -> Interview -> Context Pack -> Implementer -> Verification -> Reviewer -> Feedback` 순서는 바꾸지 않는다.
 
 ## Issue / PR Projection
@@ -114,6 +117,7 @@
 - exec plan은 `Planned` 상태의 공식 기록이며, 구현을 시작하기 전에 존재해야 한다.
 - PR은 기본적으로 local `Verifying`, `Reviewing`, `Feedback Pending` 결과를 reader-first 요약으로 전달하는 컨테이너다. detailed verification, review, feedback evidence는 exec plan이나 linked artifact에 두고, 사용자가 예외적으로 요청하지 않았다면 open PR로 게시한다.
 - `Completed` 판정은 PR의 verification 결과와 reviewer verdict, exec plan의 close-out이 함께 있어야 성립한다.
+- quality sweep에서 나온 cleanup candidate는 original issue/PR에 추가 수정으로 섞지 않고, 새 issue/PR 또는 follow-up artifact로 분리한다.
 - 완료된 exec plan은 `docs/exec-plans/completed/`로 옮기고, 후속 Issue가 이 문서를 전제조건으로 참조한다.
 - completed exec plan은 historical close-out record이며, 현재 canonical runtime과 정책은 stable source of truth 문서에서 해석한다.
 
@@ -125,3 +129,4 @@
 - [../operations/verification-contract-registry.md](../operations/verification-contract-registry.md)는 `Verifying`, `Repairing`, `Blocked` semantics와 retry budget을 명시한다.
 - [../operations/dual-agent-review-policy.md](../operations/dual-agent-review-policy.md)는 `Reviewing` 단계의 reviewer input, verdict, repair loop, evidence rule을 구체화한다.
 - [../operations/failure-to-guardrail-feedback-loop.md](../operations/failure-to-guardrail-feedback-loop.md)는 `Feedback Pending` close-out, feedback ledger, guardrail 승격 규칙을 고정한다.
+- [../operations/continuous-quality-feedback-loop.md](../operations/continuous-quality-feedback-loop.md)는 recurring quality sweep, cleanup candidate, quality sweep report handoff를 고정한다.

--- a/docs/exec-plans/active/2026-04-08-grw-23-continuous-quality-feedback-loop.md
+++ b/docs/exec-plans/active/2026-04-08-grw-23-continuous-quality-feedback-loop.md
@@ -6,8 +6,8 @@
 - Repository: `git-ranker-workflow`
 - Branch Name: `feat/grw-23-continuous-quality-feedback-loop`
 - Task Slug: `2026-04-08-grw-23-continuous-quality-feedback-loop`
-- Primary Context Pack: `workflow-docs`
-- Verification Contract Profile: `workflow-docs`
+- Primary Context Pack: `cross-repo-planning`
+- Verification Contract Profile: `cross-repo-planning`
 
 ## Problem
 
@@ -101,6 +101,9 @@
 
 ## Verification
 
+- impacted repo official source review
+  - 결과: `alexization/git-ranker@develop`의 `README.md`, `build.gradle`, `.github/workflows/quality-gate.yml`을 확인해 backend의 Gradle entrypoint와 quality gate surface를 current rollout 근거로 사용 가능함을 확인했다.
+  - 결과: `alexization/git-ranker-client@main`의 `README.md`, `package.json`, `.github/workflows/ci.yml`을 확인해 frontend의 npm script와 CI surface를 current rollout 근거로 사용 가능함을 확인했다.
 - `sed -n '1,260p' docs/operations/continuous-quality-feedback-loop.md`
   - 결과: trigger mode, signal taxonomy, detection surface, disposition vocabulary, cleanup handoff minimum이 한 문서에 정리된 것을 확인했다.
 - `sed -n '1,220p' docs/operations/quality-sweep-report-template.md`
@@ -121,12 +124,19 @@
 
 ## Verification Report
 
-- Contract profile: `workflow-docs`
+- Contract profile: `cross-repo-planning`
 - Overall status: `passed`
 - Preconditions:
-  - workflow 저장소 문서/skill 전용 변경
+  - workflow 저장소 문서/skill 전용 write scope
   - GitHub Issue `#60`
   - feature branch `feat/grw-23-continuous-quality-feedback-loop`
+  - impacted repo official source confirmed: `alexization/git-ranker@develop`, `alexization/git-ranker-client@main`
+- Command: `GitHub fetch_file alexization/git-ranker@develop README.md, build.gradle, .github/workflows/quality-gate.yml`
+  - Status: `passed`
+  - Evidence: backend의 Gradle verification surface와 existing `quality-gate.yml` base lane을 current rollout 근거로 확인했다.
+- Command: `GitHub fetch_file alexization/git-ranker-client@main README.md, package.json, .github/workflows/ci.yml`
+  - Status: `passed`
+  - Evidence: frontend의 npm scripts와 existing `ci.yml` base lane을 current rollout 근거로 확인했다.
 - Command: `sed -n '1,260p' docs/operations/continuous-quality-feedback-loop.md`
   - Status: `passed`
   - Evidence: trigger mode, signal taxonomy, detection surface, disposition, cleanup handoff minimum이 포함됐다.
@@ -151,6 +161,9 @@
 ## Evidence
 
 - current harness coverage와 gap 검토 결과
+- impacted repo official source review
+  - backend remote source: `alexization/git-ranker@develop` `README.md`, `build.gradle`, `.github/workflows/quality-gate.yml`
+  - frontend remote source: `alexization/git-ranker-client@main` `README.md`, `package.json`, `.github/workflows/ci.yml`
 - continuous quality feedback policy 본문
 - quality sweep report template 본문
 - quality sweep triage skill 본문
@@ -159,8 +172,8 @@
   - `docs/exec-plans/completed/2026-03-26-grc-02-frontend-lint-debt.md`: `coding-rule-drift -> cleanup-pr-candidate`
   - `docs/exec-plans/completed/2026-03-25-grw-04-frontend-routes-data-flow-docs.md`: `unused-code-drift -> cleanup-pr-candidate`
 - current repo structure review
-  - backend local `build.gradle`, `.github/workflows/quality-gate.yml`
-  - frontend remote `README.md`, `package.json`, `.github/workflows/ci.yml`
+  - backend official source: `alexization/git-ranker@develop` `README.md`, `build.gradle`, `.github/workflows/quality-gate.yml`
+  - frontend official source: `alexization/git-ranker-client@main` `README.md`, `package.json`, `.github/workflows/ci.yml`
 - `git diff --check` 결과
 - GitHub Issue `#60` body render 확인 결과
 

--- a/docs/exec-plans/active/2026-04-08-grw-23-continuous-quality-feedback-loop.md
+++ b/docs/exec-plans/active/2026-04-08-grw-23-continuous-quality-feedback-loop.md
@@ -1,0 +1,201 @@
+# 2026-04-08-grw-23-continuous-quality-feedback-loop
+
+- Issue ID: `GRW-23`
+- GitHub Issue: `#60`
+- Status: `In Progress`
+- Repository: `git-ranker-workflow`
+- Branch Name: `feat/grw-23-continuous-quality-feedback-loop`
+- Task Slug: `2026-04-08-grw-23-continuous-quality-feedback-loop`
+- Primary Context Pack: `workflow-docs`
+- Verification Contract Profile: `workflow-docs`
+
+## Problem
+
+현재 Harness workflow에는 verification, independent review, failure-to-guardrail feedback close-out까지의 기본 통제는 있다. 하지만 "AI가 만든 코드를 주기적으로 점검하고 품질 저하를 자동 감지해 정리 PR까지 이어지는 지속적 피드백 루프"는 source of truth와 project-local skill로 아직 고정돼 있지 않다.
+
+그 결과 현재 하네스는 개별 구현 작업의 완료 여부는 통제할 수 있지만, 시간이 지나며 누적되는 lint drift, duplication, unused code 같은 비차단 품질 저하를 어떤 trigger로 스캔하고, 어떤 evidence 형식으로 기록하며, 언제 cleanup PR 또는 guardrail follow-up으로 보내야 하는지는 작업자마다 매번 다시 정해야 한다.
+
+## Why Now
+
+`verification-contract-registry`, `dual-agent-review-policy`, `failure-to-guardrail-feedback-loop`, `guardrail-hardening` skill pack까지 갖춰지면서 "한 번의 구현 작업을 닫는 루프"는 거의 정리됐다. 이제 사용자가 기대하는 "지속적으로 품질 저하를 다시 끌어올리는 루프"를 같은 control plane 안에 붙여야 feedback system이 사후 close-out에만 머물지 않는다.
+
+또한 중복 코드, 미사용 코드, coding rule drift는 correctness regression과 달리 즉시 repair loop로 되돌리기보다는 별도 cleanup 작업이나 guardrail 승격으로 다뤄야 하는 경우가 많다. 이 경계를 canonical policy와 thin-layer skill로 먼저 잠가야 후속 repo 작업이 흔들리지 않는다.
+
+## Scope
+
+- 현재 하네스가 이미 커버하는 feedback/guardrail 범위와 비어 있는 continuous quality sweep 범위를 문서로 구분한다.
+- `docs/operations/`에 continuous quality feedback loop source of truth와 report template를 추가한다.
+- coding-rule drift, duplication, unused code를 quality sweep signal class와 cleanup candidate로 정의한다.
+- quality sweep 결과를 cleanup issue/PR handoff 또는 guardrail promotion으로 보내는 규칙을 architecture/product/governance hook에 연결한다.
+- implementer가 quality sweep 결과를 반복 가능한 형식으로 정리할 수 있도록 project-local skill을 추가한다.
+- `GRW-23` exec plan과 close-out 근거를 남긴다.
+
+## Non-scope
+
+- backend/frontend 저장소의 실제 코드 정리
+- GitHub Actions, cron, bot account 같은 runtime automation 직접 구현
+- 외부 정적 분석 도구 신규 도입
+- 기존 verification/review/failure policy 전체 재설계
+- sibling repo code write 또는 cross-repo runtime orchestration 추가
+
+## Write Scope
+
+- Primary repo: `git-ranker-workflow`
+- Allowed write paths:
+  - `docs/operations/`
+  - `docs/architecture/`
+  - `docs/product/`
+  - `.codex/skills/`
+  - `docs/exec-plans/`
+- Control-plane artifacts:
+  - `docs/exec-plans/active/2026-04-08-grw-23-continuous-quality-feedback-loop.md`
+  - `docs/exec-plans/completed/2026-04-08-grw-23-continuous-quality-feedback-loop.md`
+  - `/tmp/grw-23-issue-body.md`
+- Explicitly forbidden:
+  - sibling app repo code write
+  - `.github/workflows/` 등 runtime automation 추가
+  - scope 밖 stable source of truth mass update
+- Network / external systems:
+  - GitHub Issue create/view
+- Escalation triggers:
+  - 없음
+
+## Outputs
+
+- `docs/operations/continuous-quality-feedback-loop.md`
+- `docs/operations/quality-sweep-report-template.md`
+- `.codex/skills/quality-sweep-triage/SKILL.md`
+- 관련 architecture/product/operations/skills registry hook
+- `docs/exec-plans/active/2026-04-08-grw-23-continuous-quality-feedback-loop.md`
+
+## Working Decisions
+
+- 현재 하네스에 있는 `failure-to-guardrail`은 "작업 close-out feedback loop"로 유지하고, 새 문서는 이를 대체하지 않는 "continuous quality sweep loop"로 분리한다.
+- quality sweep은 state machine에 새 terminal stage를 추가하지 않고, `Feedback` 단계에서 후속 cleanup issue/PR 또는 guardrail follow-up을 생성하는 recurring surface로 정의한다.
+- non-blocking quality drift는 기존 작업의 완료 판정을 자동으로 뒤집지 않는다. 대신 새 cleanup work item 또는 guardrail follow-up으로 분리한다.
+- quality signal class는 우선 `coding-rule-drift`, `duplication-drift`, `unused-code-drift` 세 가지로 고정하고, 저장소별 detector 구현은 각 repo contract가 소유한다.
+- project-local skill은 canonical policy를 thin layer로 operationalize하는 수준에 머문다.
+- enterprise-grade rollout은 `workflow = policy/triage`, `repo = detector/CI/runtime` 분리 원칙을 따른다.
+- PR blocking lane에는 fast/deterministic/low-noise signal만 넣고, duplication과 wide dead code scan은 scheduled sweep lane으로 분리한다.
+- auto-generated cleanup PR은 autofixable low-risk surface에만 허용하고, duplication refactor와 backend dead code removal은 issue-first를 기본으로 한다.
+
+## Enterprise Review
+
+- 현재 `workflow`에 넣은 방식은 enterprise harness의 control-plane 역할로는 적절하다. policy, taxonomy, evidence, handoff를 중앙에서 고정하고, detector runtime은 각 repo가 소유하는 분리가 맞다.
+- 비효율적인 방식은 `workflow` 저장소가 backend/frontend 코드를 직접 스캔하거나, 모든 GC를 중앙 스케줄러 하나로 몰아넣는 것이다. 현재 control-plane map과 context pack registry 기준에도 이 방식은 boundary를 깨뜨린다.
+- 우리 구조에서는 backend와 frontend가 이미 각자 CI/workflow surface를 갖고 있으므로, GC도 각 repo의 PR gate와 scheduled workflow에 붙이는 것이 가장 적절하다.
+- 가장 중요한 수정점은 "자동 PR 생성"의 범위를 줄이는 것이다. enterprise 방식에서는 auto-PR을 전면 허용하지 않고, deterministic autofix가 가능한 low-risk surface만 허용한다.
+
+## Recommended Rollout
+
+1. `workflow`는 지금처럼 policy, report template, skill, cleanup handoff만 유지한다.
+2. backend는 existing Gradle + `quality-gate.yml` 위에 repo-local GC lane을 추가한다.
+   - PR blocking lane: low-noise static analysis만 추가
+   - scheduled sweep lane: duplication/wide dead code scan
+   - auto-PR: 기본적으로 끄고, 안전한 import/format 계열만 추후 검토
+3. frontend는 existing npm scripts + `ci.yml` 위에 repo-local GC lane을 추가한다.
+   - PR blocking lane: `lint` 기반 coding-rule drift와 high-confidence unused detector 일부
+   - scheduled sweep lane: duplication, wide unused file/export/dependency scan
+   - auto-PR: lint autofix나 high-confidence unused cleanup처럼 bounded surface만 허용
+4. repo-local sweep 결과는 `quality sweep report` 형식으로 다시 workflow policy에 handoff한다.
+
+## Verification
+
+- `sed -n '1,260p' docs/operations/continuous-quality-feedback-loop.md`
+  - 결과: trigger mode, signal taxonomy, detection surface, disposition vocabulary, cleanup handoff minimum이 한 문서에 정리된 것을 확인했다.
+- `sed -n '1,220p' docs/operations/quality-sweep-report-template.md`
+  - 결과: quality sweep report 필수 필드, disposition vocabulary, minimal example이 canonical artifact로 재사용 가능한 것을 확인했다.
+- `sed -n '1,260p' .codex/skills/quality-sweep-triage/SKILL.md`
+  - 결과: quality sweep trigger, required evidence, disposition handoff, `request-intake -> issue-to-exec-plan` 연결이 thin-layer skill에 포함된 것을 확인했다.
+- `rg -n "continuous quality|quality sweep|coding-rule-drift|duplication-drift|unused-code-drift|quality-sweep-triage" docs .codex`
+  - 결과: operations, architecture, product, skill registry, active exec plan이 같은 vocabulary와 hook을 공유하는 것을 확인했다.
+- representative quality signal simulation 2건
+  - 결과: `GRC-02`의 lint warning debt는 `coding-rule-drift -> cleanup-pr-candidate`로, `GRW-04`의 unused ranking prefetch 경로는 `unused-code-drift -> cleanup-pr-candidate`로 현재 policy에 대입 가능함을 확인했다.
+- current repo structure review
+  - 결과: backend는 local Gradle project와 existing `quality-gate.yml`을 이미 갖고 있어 repo-local GC lane 확장에 적합했다.
+  - 결과: frontend는 remote `README.md`, `package.json`, existing `ci.yml` 기준으로 repo-local npm script + GitHub Actions 확장이 가장 자연스러웠고, 현재 workflow worktree에는 local frontend checkout이 없으므로 implementation 전 worktree 준비가 필요함을 확인했다.
+- `git diff --check`
+  - 결과: whitespace 또는 patch formatting 오류가 없음을 확인했다.
+- `gh issue view --repo alexization/git-ranker-workflow 60 --json body,title,number`
+  - 결과: Issue `#60` 본문이 섹션과 줄바꿈을 유지한 채 생성된 것을 확인했다.
+
+## Verification Report
+
+- Contract profile: `workflow-docs`
+- Overall status: `passed`
+- Preconditions:
+  - workflow 저장소 문서/skill 전용 변경
+  - GitHub Issue `#60`
+  - feature branch `feat/grw-23-continuous-quality-feedback-loop`
+- Command: `sed -n '1,260p' docs/operations/continuous-quality-feedback-loop.md`
+  - Status: `passed`
+  - Evidence: trigger mode, signal taxonomy, detection surface, disposition, cleanup handoff minimum이 포함됐다.
+- Command: `sed -n '1,220p' docs/operations/quality-sweep-report-template.md`
+  - Status: `passed`
+  - Evidence: quality sweep report 필수 필드와 example이 canonical template로 정리됐다.
+- Command: `sed -n '1,260p' .codex/skills/quality-sweep-triage/SKILL.md`
+  - Status: `passed`
+  - Evidence: cleanup candidate, guardrail follow-up, repair-now triage와 handoff가 skill에 반영됐다.
+- Command: `rg -n "continuous quality|quality sweep|coding-rule-drift|duplication-drift|unused-code-drift|quality-sweep-triage" docs .codex`
+  - Status: `passed`
+  - Evidence: architecture, operations, product, skills registry, exec plan이 같은 hook을 참조한다.
+- Command: `git diff --check`
+  - Status: `passed`
+  - Evidence: formatting 오류가 없다.
+- Command: `gh issue view --repo alexization/git-ranker-workflow 60 --json body,title,number`
+  - Status: `passed`
+  - Evidence: issue body render가 깨지지 않았다.
+- Failure summary: 없음
+- Next action: 사용자 검토 또는 후속 independent review handoff
+
+## Evidence
+
+- current harness coverage와 gap 검토 결과
+- continuous quality feedback policy 본문
+- quality sweep report template 본문
+- quality sweep triage skill 본문
+- 관련 hook 문서 grep 결과
+- representative quality signal simulation 2건
+  - `docs/exec-plans/completed/2026-03-26-grc-02-frontend-lint-debt.md`: `coding-rule-drift -> cleanup-pr-candidate`
+  - `docs/exec-plans/completed/2026-03-25-grw-04-frontend-routes-data-flow-docs.md`: `unused-code-drift -> cleanup-pr-candidate`
+- current repo structure review
+  - backend local `build.gradle`, `.github/workflows/quality-gate.yml`
+  - frontend remote `README.md`, `package.json`, `.github/workflows/ci.yml`
+- `git diff --check` 결과
+- GitHub Issue `#60` body render 확인 결과
+
+## Risks or Blockers
+
+- quality sweep을 verification completion gate처럼 오해하게 쓰면 기존 완료 semantics가 흔들릴 수 있다.
+- runtime automation이 없는 상태에서 "자동 PR 생성"을 과장하면 source of truth와 실제 구현이 어긋날 수 있다.
+- duplication/unused code detector는 repo별 도구 의존성이 달라 workflow 문서가 구현 세부를 과도하게 소유하면 boundary가 무너진다.
+
+## Next Preconditions
+
+- `GRB-05`: backend repo-local GC baseline 정렬
+- `GRC-06`: frontend repo-local GC baseline 정렬
+- frontend 구현 전 local worktree 준비 또는 remote canonical source 기반 planning 고정
+- cleanup PR publish automation은 low-risk autofix surface가 검증된 뒤 별도 runtime/CI work item으로 분리
+
+## Docs Updated
+
+- `.codex/skills/README.md`
+- `.codex/skills/quality-sweep-triage/SKILL.md`
+- `docs/architecture/harness-system-map.md`
+- `docs/operations/README.md`
+- `docs/operations/continuous-quality-feedback-loop.md`
+- `docs/operations/failure-to-guardrail-feedback-loop.md`
+- `docs/operations/quality-sweep-report-template.md`
+- `docs/operations/workflow-governance.md`
+- `docs/product/harness-roadmap.md`
+- `docs/product/work-item-catalog.md`
+- `docs/exec-plans/active/2026-04-08-grw-23-continuous-quality-feedback-loop.md`
+
+## Independent Review
+
+- 이번 턴에서는 session-isolated reviewer pool을 실행하지 않았다.
+- 따라서 canonical independent review evidence와 `Completed` close-out은 아직 남아 있다.
+
+## Skill Consideration
+
+이번 작업은 canonical policy와 thin-layer skill을 함께 추가해 continuous quality feedback loop를 workflow control plane에 반영하는 일이다. skill은 policy를 대체하지 않고, quality sweep 결과를 cleanup candidate 또는 guardrail follow-up으로 분류하는 반복 절차만 담당한다.

--- a/docs/exec-plans/active/2026-04-08-grw-23-continuous-quality-feedback-loop.md
+++ b/docs/exec-plans/active/2026-04-08-grw-23-continuous-quality-feedback-loop.md
@@ -115,7 +115,7 @@
 - representative quality signal simulation 2건
   - 결과: `GRC-02`의 lint warning debt는 `coding-rule-drift -> cleanup-pr-candidate`로, `GRW-04`의 unused ranking prefetch 경로는 `unused-code-drift -> cleanup-pr-candidate`로 현재 policy에 대입 가능함을 확인했다.
 - current repo structure review
-  - 결과: backend는 local Gradle project와 existing `quality-gate.yml`을 이미 갖고 있어 repo-local GC lane 확장에 적합했다.
+  - 결과: backend는 remote `README.md`, `build.gradle`, existing `quality-gate.yml` 기준으로 Gradle entrypoint와 quality gate surface가 확인돼 repo-local GC lane 확장에 적합했다.
   - 결과: frontend는 remote `README.md`, `package.json`, existing `ci.yml` 기준으로 repo-local npm script + GitHub Actions 확장이 가장 자연스러웠고, 현재 workflow worktree에는 local frontend checkout이 없으므로 implementation 전 worktree 준비가 필요함을 확인했다.
 - `git diff --check`
   - 결과: whitespace 또는 patch formatting 오류가 없음을 확인했다.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -10,4 +10,6 @@
 - [verification-contract-registry.md](verification-contract-registry.md)
 - [dual-agent-review-policy.md](dual-agent-review-policy.md)
 - [failure-to-guardrail-feedback-loop.md](failure-to-guardrail-feedback-loop.md)
+- [continuous-quality-feedback-loop.md](continuous-quality-feedback-loop.md)
 - [guardrail-ledger-template.md](guardrail-ledger-template.md)
+- [quality-sweep-report-template.md](quality-sweep-report-template.md)

--- a/docs/operations/continuous-quality-feedback-loop.md
+++ b/docs/operations/continuous-quality-feedback-loop.md
@@ -1,0 +1,140 @@
+# Continuous Quality Feedback Loop
+
+이 문서는 [../architecture/harness-system-map.md](../architecture/harness-system-map.md)의 `Feedback` 이후에도 품질 저하를 다시 끌어올리기 위한 recurring quality sweep 규칙을 고정한다. [verification-contract-registry.md](verification-contract-registry.md)가 현재 작업의 completion gate를 잠그고, [failure-to-guardrail-feedback-loop.md](failure-to-guardrail-feedback-loop.md)가 close-out 시점의 failure promotion을 잠근다면, 이 문서는 "언제 주기적 또는 targeted quality sweep을 돌리고", "lint drift, duplication, unused code를 어떻게 분류하며", "언제 cleanup PR candidate 또는 guardrail follow-up으로 보내는가"를 잠근다.
+
+관련 운영 규칙은 [workflow-governance.md](workflow-governance.md)를 따른다.
+
+## Policy Invariants
+
+- continuous quality sweep은 verification, review, feedback close-out을 대체하지 않는다. 현재 issue의 완료 판정은 계속 verification contract와 reviewer verdict가 결정한다.
+- quality sweep은 `Completed` 뒤의 recurring surface다. 이미 닫힌 issue를 다시 열지 않고, 필요한 경우 새 cleanup work item 또는 guardrail follow-up을 만든다.
+- quality sweep은 success path와 failure path 모두에서 실행될 수 있다. 성공 경로에서는 non-blocking quality drift를 찾고, 실패 경로에서는 반복되는 detector gap을 guardrail 후보로 연결한다.
+- quality signal entry는 signal class 하나당 하나씩 남긴다. coding rule drift와 unused code를 같은 entry에 섞지 않는다.
+- correctness, security, reliability에 직접 영향을 주는 blocking finding은 cleanup candidate로 축소하지 않는다. 이 경우 `repair-now` 또는 새 bug/repair issue로 보낸다.
+- workflow control plane은 trigger, taxonomy, evidence, handoff만 소유한다. 저장소별 detector 구현과 명령은 각 repo entry doc, verification contract, build script가 소유한다.
+- quality sweep에서 반복적으로 드러나는 detector gap, noisy lint baseline, missing CI gate는 [failure-to-guardrail-feedback-loop.md](failure-to-guardrail-feedback-loop.md)의 guardrail promotion으로 다시 연결한다.
+
+## Trigger Modes
+
+| Trigger mode | When to use | Typical owner | Expected output |
+| --- | --- | --- | --- |
+| `post-closeout` | 특정 issue/PR이 `Completed`로 닫힌 직후, 이번 diff 주변에서 quality drift를 다시 점검해야 할 때 | implementer 또는 reviewer coordinator | quality sweep report, cleanup candidate 여부 |
+| `scheduled` | 저장소별 cadence에 따라 주기적으로 lint drift, duplication, unused code를 점검할 때 | repo maintainer, automation runtime, scheduled harness request | quality sweep report, cleanup backlog or PR candidate |
+| `targeted` | 특정 경로, 반복 finding, reviewer note를 근거로 한정 스캔이 필요할 때 | implementer, reviewer, maintainer | bounded sweep result and handoff |
+
+추가 규칙:
+
+- workflow control plane은 scheduler 자체를 소유하지 않는다. `scheduled` trigger는 사용자의 요청, repo runtime, CI, 운영자 반복 작업 등 어떤 형태로 들어와도 되지만, 들어온 뒤의 분류와 handoff 규칙은 이 문서를 따른다.
+- trigger mode가 무엇이든 original issue의 completion verdict는 그대로 유지하고, 새 follow-up work item을 별도로 만든다.
+
+## Quality Signal Taxonomy
+
+| Signal class | Typical signal | Default question | Preferred follow-up |
+| --- | --- | --- | --- |
+| `coding-rule-drift` | lint warning 증가, rule suppression 증가, formatter drift, repo rule과 맞지 않는 반복 패턴 | deterministic rule이나 CI gate가 더 일찍 막았어야 하는가 | `cleanup-pr-candidate` 또는 `guardrail-follow-up` |
+| `duplication-drift` | copy-paste된 로직, 유사한 patch가 여러 파일로 퍼짐, 같은 handoff/boilerplate 반복 | 구조를 바꾸는 bounded refactor로 줄일 수 있는가 | `cleanup-pr-candidate` |
+| `unused-code-drift` | unused export/helper/dependency, stale flag, dead path, 더 이상 호출되지 않는 route or config | 안전하게 제거 가능한 bounded dead code인가 | `cleanup-pr-candidate` 또는 `repair-now` |
+
+추가 규칙:
+
+- signal class는 detector가 아니라 quality drift의 종류를 의미한다.
+- blocking runtime regression을 동반하는 dead path나 stale config는 `unused-code-drift`로 기록할 수 있어도 disposition은 `repair-now`일 수 있다.
+- 같은 signal class가 반복되는데 detector나 gate가 없으면 quality drift 자체와 detector gap을 별도 root cause로 나눌 수 있다.
+
+## Detection Surface Rule
+
+quality sweep report에는 어떤 detector 또는 inspection surface를 썼는지 반드시 남긴다. 가능한 source는 아래 우선순위를 따른다.
+
+1. impacted repo의 entry doc, package/build script, verification contract에 이미 정의된 deterministic command
+2. repo-specific static analysis surface
+3. reviewer note, completed exec plan, grep, manual code reading 같은 bounded inspection
+
+추가 규칙:
+
+- workflow 문서는 duplication/unused detector의 정확한 도구 이름을 강제하지 않는다.
+- 반복되는 signal class인데 impacted repo에 detector가 전혀 없다면, 그 부재 자체를 `guardrail-follow-up` 후보로 남긴다.
+- evidence 없이 "중복 같다", "안 쓰는 것 같다"만 적지 않는다. 최소한 grep, command output, path inventory, review note 중 하나가 있어야 한다.
+
+## Enterprise Execution Pattern
+
+enterprise-grade harness에서는 control plane과 detector runtime을 한 저장소에 몰아넣지 않는다. 기본 실행 패턴은 아래 세 갈래로 나눈다.
+
+1. PR blocking lane
+   - repo-local CI에서 빠르고 deterministic한 rule만 gate로 건다.
+   - 예: lint, typecheck, build, unused import/variable, low-noise static analysis
+2. Scheduled sweep lane
+   - heavier duplication, unused export/file/dependency, wide-scope dead code scan은 default branch 기준 scheduled workflow나 maintainer-triggered workflow로 분리한다.
+   - 이 lane은 original feature PR completion을 막기보다 cleanup candidate와 guardrail follow-up을 만든다.
+3. Autofix lane
+   - auto-generated cleanup PR은 semantic risk가 낮고 tool이 deterministic fix를 제공하는 경우에만 허용한다.
+   - 예: formatter, lint autofix, unused import/dependency cleanup
+
+추가 규칙:
+
+- duplication refactor는 기본적으로 `cleanup-pr-candidate`다. report는 자동화할 수 있어도 refactor PR 생성은 bounded scope와 reviewability가 잠길 때만 연다.
+- backend dead code removal은 framework reflection, Spring wiring, batch/job registration 영향이 있을 수 있으므로 issue-first를 기본으로 한다.
+- frontend unused export/file/dependency cleanup은 repo-specific detector가 high-confidence fix를 제공하면 autofix lane 후보가 될 수 있다.
+- control plane은 lane 선택, evidence, handoff를 잠그고, lane 실행 자체는 각 repo CI/workflow가 소유한다.
+
+## Disposition Vocabulary
+
+| Disposition | Choose when | Typical output |
+| --- | --- | --- |
+| `repair-now` | quality sweep이 사실상 correctness, contract, reliability, security bug를 다시 발견한 경우 | 새 bug/repair issue 또는 즉시 repair handoff |
+| `cleanup-pr-candidate` | bounded write scope와 deterministic evidence가 있어 별도 cleanup issue/PR로 안전하게 분리 가능한 경우 | quality sweep report, cleanup issue/exec plan 또는 automated cleanup PR handoff |
+| `guardrail-follow-up` | root cause가 missing detector, missing policy, weak CI gate, repeated noisy baseline처럼 system asset 부족인 경우 | feedback ledger entry, follow-up docs/skill/test/ci/template asset |
+| `no-action` | false positive, duplicate report, 이미 current baseline에서 해소됨, 지금 자산화할 가치가 없는 one-off note인 경우 | explicit rationale only |
+
+## Selection Rules
+
+1. signal이 blocking bug면 `cleanup-pr-candidate`로 축소하지 않고 `repair-now`를 고른다.
+2. non-blocking quality drift이고 bounded scope와 evidence가 있으면 `cleanup-pr-candidate`를 우선 검토한다.
+3. 같은 signal class가 반복되는데 detector나 gate가 없으면 `guardrail-follow-up`을 검토한다.
+4. confidence가 낮거나 write scope를 잠글 수 없으면 바로 cleanup PR을 약속하지 말고 `no-action` 또는 planning follow-up으로 돌린다.
+5. quality sweep에서 나온 cleanup candidate는 original issue/PR에 뒤늦게 끼워 넣지 않는다. 새 issue/PR로 분리한다.
+6. 하나의 cleanup candidate는 하나의 목표만 가진다. `Issue 1개 = PR 1개` 원칙을 그대로 따른다.
+
+## Cleanup Handoff Rule
+
+`cleanup-pr-candidate`를 선택했으면 최소한 아래를 next work item에 넘긴다.
+
+- 대상 저장소
+- bounded scan scope
+- signal class
+- detector 또는 inspection surface
+- 핵심 evidence
+- non-scope
+- follow-up owner 또는 next action
+
+추가 규칙:
+
+- 현재 runtime이 직접 PR을 만들 수 있어도, scope가 잠겨 있지 않으면 먼저 issue와 exec plan으로 고정한다.
+- automated cleanup PR은 allowed write scope, evidence, verification command를 설명할 수 있을 때만 허용한다.
+- automated cleanup PR은 semantic risk가 낮고 repo-local autofix surface가 이미 검증된 signal class에만 쓴다.
+- cleanup candidate가 여러 개면 path나 root cause별로 issue/PR을 분리한다.
+
+## Quality Sweep Report Minimum
+
+quality sweep 결과는 exec plan close-out, review note, 또는 follow-up artifact 중 최소 한 곳에 [quality-sweep-report-template.md](quality-sweep-report-template.md)의 형식으로 남긴다.
+
+필수 필드:
+
+- trigger mode
+- source repo와 source task/PR/baseline
+- scan scope
+- detection surface
+- signal class
+- trigger signal
+- severity
+- disposition
+- evidence
+- owner / next action
+
+quality sweep report가 없으면 cleanup candidate나 guardrail follow-up handoff가 잠긴 것으로 보지 않는다.
+
+## Relationship To Other Policies
+
+- current issue의 completion gate와 repair budget은 계속 [verification-contract-registry.md](verification-contract-registry.md)가 canonical source다.
+- reviewer verdict vocabulary와 blocking review finding은 계속 [dual-agent-review-policy.md](dual-agent-review-policy.md)가 canonical source다.
+- close-out 시점의 failure taxonomy, guardrail promotion decision, ledger entry는 계속 [failure-to-guardrail-feedback-loop.md](failure-to-guardrail-feedback-loop.md)가 canonical source다.
+- 이 문서는 close-out 이후 recurring quality sweep과 cleanup candidate handoff만 맡는다.

--- a/docs/operations/failure-to-guardrail-feedback-loop.md
+++ b/docs/operations/failure-to-guardrail-feedback-loop.md
@@ -144,4 +144,6 @@ feedback close-out artifact가 비어 있으면 완료로 보지 않는다.
 - verification 재시도, budget, `Blocked` 전환은 계속 [verification-contract-registry.md](verification-contract-registry.md)가 canonical source다.
 - reviewer verdict vocabulary와 blocking finding 기준은 계속 [dual-agent-review-policy.md](dual-agent-review-policy.md)가 canonical source다.
 - 이 문서는 verification과 review의 최신 결과가 나온 뒤, 그 결과를 다음 guardrail 자산으로 연결하는 close-out 규칙만 맡는다.
+- recurring lint drift, duplication, unused code sweep과 cleanup candidate handoff는 [continuous-quality-feedback-loop.md](continuous-quality-feedback-loop.md)가 맡는다.
+- quality sweep에서 detector gap이나 repeated drift가 guardrail follow-up으로 좁혀지면, promotion decision vocabulary는 다시 이 문서를 따른다.
 - 후속 skill pack과 template는 이 문서를 압축해 재사용할 수 있지만, 승격 대상 vocabulary와 `no-new-guardrail` 기준은 계속 이 문서가 canonical source다.

--- a/docs/operations/quality-sweep-report-template.md
+++ b/docs/operations/quality-sweep-report-template.md
@@ -1,0 +1,64 @@
+# Quality Sweep Report Template
+
+이 문서는 [continuous-quality-feedback-loop.md](continuous-quality-feedback-loop.md)의 canonical quality sweep report 형식을 제공한다. cleanup candidate, guardrail follow-up, repair-now handoff는 최소한 아래 필드를 포함한 report 하나로 남긴다.
+
+## Report Template
+
+```md
+## Quality Sweep Report
+- Date:
+- Trigger mode:
+  - `post-closeout | scheduled | targeted`
+- Source repo:
+- Source task / PR / baseline:
+- Scan scope:
+- Detection surface:
+- Signal class:
+  - `coding-rule-drift | duplication-drift | unused-code-drift`
+- Trigger signal:
+- Root cause hypothesis:
+- Severity:
+  - `blocking | non-blocking`
+- Existing guardrail:
+- Disposition:
+  - `repair-now | cleanup-pr-candidate | guardrail-follow-up | no-action`
+- Follow-up asset / issue / PR:
+- Owner / next action:
+- Evidence:
+- Notes:
+```
+
+## Writing Rules
+
+- report 하나에는 signal class 하나만 적는다.
+- `Trigger signal`은 symptom이고, `Root cause hypothesis`는 왜 이 quality drift가 다시 생길 수 있는지에 대한 가설이다.
+- `Detection surface`에는 command, grep, review note, repo-specific detector 중 실제로 쓴 경로를 적는다.
+- `Existing guardrail`에는 이미 있던 lint rule, docs rule, CI gate, detector가 있으면 적고, 없으면 `없음`이라고 적는다.
+- `cleanup-pr-candidate`를 고르면 follow-up asset에 대상 issue, PR candidate, exec plan path 중 최소 하나를 적는다.
+- `no-action`을 고르면 `Notes`에 왜 지금은 follow-up을 만들지 않는지 적는다.
+
+## Minimal Example
+
+```md
+## Quality Sweep Report
+- Date: `2026-04-08`
+- Trigger mode:
+  - `post-closeout`
+- Source repo: `git-ranker-client`
+- Source task / PR / baseline: `docs/exec-plans/completed/2026-04-08-sample.md`
+- Scan scope: `src/features/ranking`
+- Detection surface: `npm run lint` warning summary와 reviewer note
+- Signal class:
+  - `unused-code-drift`
+- Trigger signal: unused ranking prefetch helper가 current route tree에서 더 이상 호출되지 않는다.
+- Root cause hypothesis: route refactor 이후 stale helper cleanup이 follow-up 없이 남았다.
+- Severity:
+  - `non-blocking`
+- Existing guardrail: `없음`
+- Disposition:
+  - `cleanup-pr-candidate`
+- Follow-up asset / issue / PR: cleanup issue 초안
+- Owner / next action: request-intake로 새 cleanup issue를 시작한다.
+- Evidence: lint warning, grep path inventory, reviewer note
+- Notes: current issue completion verdict는 유지한다.
+```

--- a/docs/operations/workflow-governance.md
+++ b/docs/operations/workflow-governance.md
@@ -33,6 +33,7 @@
 - 하나의 PR은 하나의 목표만 해결한다
 - 한 PR에서 여러 저장소를 동시에 건드리는 경우는 피한다
 - cross-repo 작업은 `workflow 문서 PR`과 `앱 코드 PR`로 나눈다
+- quality sweep에서 나온 cleanup/refactor/unused code 후보도 원본 issue/PR에 끼워 넣지 않고 별도 issue/PR로 분리한다
 
 ## 요청 intake 규칙
 
@@ -87,6 +88,7 @@
 - review evidence 최소 필드: implementer, reviewer, reviewer input, verdict, blocking finding 또는 no-blocking note
 - reviewer pool의 final verdict owner와 역할별 reviewer를 함께 남긴다
 - feedback evidence 최소 필드: stage, failure class, promotion decision, follow-up asset 또는 `no new guardrail` 이유, 핵심 evidence
+- quality sweep evidence 최소 필드: trigger mode, scan scope, signal class, disposition, follow-up asset 또는 `no-action` 이유, 핵심 evidence
 - 문서 업데이트: source of truth 반영 여부
 
 문서 전용 작업도 무엇을 바꿨는지와 어떤 기준으로 확인했는지는 남겨야 한다. 다만 본문에는 판단에 필요한 요약만 적고, raw 명령이나 경로 inventory는 close-out artifact로 내린다.
@@ -168,6 +170,7 @@
 - 사용자가 다르게 요청하지 않았다면 independent review를 끝낸 뒤 PR을 publish한다.
 - source of truth 문서를 함께 업데이트하거나, 업데이트가 불필요한 이유를 남긴다.
 - 검증 명령과 최종 상태는 close-out artifact에 반드시 남기고, PR 본문에는 필요한 요약만 남긴다.
+- quality sweep에서 나온 non-blocking cleanup candidate는 current issue에 섞지 말고 별도 work item으로 넘긴다.
 - 새로 생긴 반복 절차가 있다면 skill 후보로 제안하되, 이번 Issue 범위를 넘는 구현은 하지 않는다.
 - 모호한 선택지가 여러 개면 [docs/product/work-item-catalog.md](../product/work-item-catalog.md)의 기본 결정을 따른다.
 - 실행 중 예상치 못한 dirty change가 있으면 되돌리지 말고 영향 여부만 확인한다.

--- a/docs/product/harness-roadmap.md
+++ b/docs/product/harness-roadmap.md
@@ -8,7 +8,7 @@
 2. 실행 가능한 작업은 task type에 맞는 최소 컨텍스트와 명시적 write scope를 가진다.
 3. 구현 Agent는 결정론적 검증 명령을 통과하기 전까지 작업 완료를 주장할 수 없다.
 4. 코드 검토는 구현 Agent 자신이 아니라, 현재 Codex 세션에서 분리 생성한 session-isolated sub-agent reviewer pool이 수행한다.
-5. 실패는 다음 문서, skill, 테스트, CI 가드레일로 축적된다.
+5. 실패와 non-blocking quality drift는 다음 문서, skill, 테스트, CI 가드레일 또는 cleanup 작업으로 축적된다.
 
 ## 이번 계획의 고정 결정
 
@@ -22,6 +22,7 @@
 - 현재 control plane source of truth는 `docs/architecture/`, `docs/operations/`, `docs/product/`, `docs/exec-plans/`로 한정한다.
 - 새 작업은 항상 exec plan으로 고정한 뒤 시작한다.
 - 사용자가 다르게 요청하지 않으면 PR은 independent review와 feedback evidence를 먼저 채운 뒤 open 상태로 publish한다.
+- feedback close-out 뒤에는 scheduled 또는 targeted quality sweep signal을 cleanup candidate 또는 guardrail follow-up으로 다시 분류할 수 있다.
 
 ## 목표 상태
 
@@ -35,6 +36,7 @@
 6. verification contract registry에 정의된 명령이 통과해야 다음 단계로 넘어간다.
 7. reviewer sub-agent pool과 reviewer coordinator는 [../operations/dual-agent-review-policy.md](../operations/dual-agent-review-policy.md)에 따라 역할별로 구현 diff와 검증 결과를 검토하고, 통과 또는 수정 요청을 결정한다.
 8. 실패한 작업은 [../operations/failure-to-guardrail-feedback-loop.md](../operations/failure-to-guardrail-feedback-loop.md)의 feedback ledger에 남기고 다음 가드레일 후보로 전환한다.
+9. `Completed` 뒤의 quality sweep은 lint drift, duplication, unused code를 새 cleanup issue/PR candidate 또는 guardrail follow-up으로 보낸다.
 
 ## 권장 실행 순서
 
@@ -58,11 +60,14 @@
 13. `GRW-S08` verification/review-loop skill pack
 14. `GRW-S09` guardrail-hardening skill pack
 15. `GRW-18` workflow repo pilot issue로 새 흐름 1회 검증
+16. `GRW-23` continuous quality feedback loop 정렬
 
 ### Phase 3. Repo-Specific Contracts
 
-16. `GRB-04` backend verification contract 정규화
-17. `GRC-05` frontend verification contract 정규화
+17. `GRB-04` backend verification contract 정규화
+18. `GRC-05` frontend verification contract 정규화
+19. `GRB-05` backend GC baseline 정렬
+20. `GRC-06` frontend GC baseline 정렬
 
 ## 바로 다음에 추천하는 작업
 
@@ -85,3 +90,4 @@
 - 구현 Agent는 자기 자신의 결과를 최종 승인하지 않는다.
 - 같은 실패가 반복되면 다음 턴에서는 가드레일이 하나 더 생겨야 한다.
 - `Feedback Pending` close-out에는 guardrail 승격 대상 또는 `no new guardrail` 이유가 남아야 한다.
+- quality sweep에서 발견한 non-blocking cleanup candidate는 original issue 완료 여부와 분리해 새 work item으로 넘긴다.

--- a/docs/product/work-item-catalog.md
+++ b/docs/product/work-item-catalog.md
@@ -1,6 +1,6 @@
 # Work Item Catalog
 
-이 문서는 현재 하네스 시스템 구축을 위한 작업 카탈로그다. 모든 작업은 `요청 라우팅`, `컨텍스트 제한`, `도구 경계`, `결정론적 검증`, `구현/리뷰 Agent 분리`, `실패의 가드레일화`를 차례로 고정하는 방향으로 진행한다.
+이 문서는 현재 하네스 시스템 구축을 위한 작업 카탈로그다. 모든 작업은 `요청 라우팅`, `컨텍스트 제한`, `도구 경계`, `결정론적 검증`, `구현/리뷰 Agent 분리`, `실패의 가드레일화`, `non-blocking quality drift의 cleanup 분리`를 차례로 고정하는 방향으로 진행한다.
 
 ## 사용 순서
 
@@ -132,6 +132,17 @@
 - 산출물: pilot exec plan, verification 결과, review 결과, feedback ledger entry
 - 검증: 새 흐름만으로 작업이 끝까지 닫히는지 확인
 
+### GRW-23. continuous quality feedback loop 정렬
+
+- 저장소: `git-ranker-workflow`
+- 선행조건: `GRW-15`, `GRW-16`, `GRW-17`, `GRW-S09`
+- 권장 write scope: `docs/operations`, `docs/architecture`, `docs/product`, `.codex/skills/`, `docs/exec-plans`
+- 기본 결정: quality sweep은 verification completion gate가 아니라 `Completed` 뒤 recurring surface다. non-blocking lint drift, duplication, unused code는 original issue를 다시 열지 않고 separate cleanup issue/PR candidate로 분리한다. detector나 gate 부재가 반복되면 guardrail follow-up으로 승격한다.
+- 핵심 작업: continuous quality feedback loop policy, quality sweep report template, signal taxonomy, cleanup handoff rule, thin-layer skill을 source of truth와 registry에 반영한다.
+- 비범위: repo-specific detector 구현, 실제 automation runtime, backend/frontend 앱 코드 cleanup
+- 산출물: quality sweep policy, report template, skill, 관련 roadmap/system map/governance hook, `GRW-23` exec plan
+- 검증: 문서 본문 리뷰, hook grep, representative quality signal simulation
+
 ## Skill Track
 
 ### GRW-S06. intake/ambiguity skill pack
@@ -191,6 +202,17 @@
 - 산출물: backend verification contract, 필요한 문서/스크립트 정리
 - 검증: contract에 적힌 명령과 실제 실행 결과 대조
 
+### GRB-05. backend GC baseline 정렬
+
+- 저장소: `git-ranker`
+- 선행조건: `GRB-04`, `GRW-23`
+- 권장 write scope: `build.gradle`, backend static analysis config, `.github/workflows/`, backend README 또는 verification entry docs
+- 기본 결정: backend GC는 workflow repo가 아니라 backend repo의 Gradle task와 GitHub Actions가 소유한다. PR gate에는 low-noise static analysis만 넣고, duplication/wide dead code scan은 scheduled quality sweep으로 분리한다. Spring wiring, reflection, batch registration 영향이 큰 dead code removal은 issue-first를 기본으로 한다.
+- 핵심 작업: repo-local GC command surface를 추가하고, existing `quality-gate.yml`과 scheduled workflow에 blocking lane / sweep lane을 분리하며, cleanup candidate와 guardrail follow-up evidence를 `GRW-23` policy 형식에 맞춘다.
+- 비범위: workflow repo policy 재설계, broad auto-delete, frontend repo 변경
+- 산출물: backend GC command, CI/scheduled workflow, repo-local docs update, `GRB-05` exec plan
+- 검증: PR gate command 통과, scheduled sweep artifact shape 확인, representative duplication/unused signal triage
+
 ## Client Track
 
 ### GRC-05. frontend verification contract 정규화
@@ -203,6 +225,17 @@
 - 비범위: UI 개편
 - 산출물: frontend verification contract, 필요한 문서/스크립트 정리
 - 검증: contract에 적힌 명령과 실제 실행 결과 대조
+
+### GRC-06. frontend GC baseline 정렬
+
+- 저장소: `git-ranker-client`
+- 선행조건: `GRC-05`, `GRW-23`
+- 권장 write scope: `package.json`, frontend static analysis config, `.github/workflows/`, frontend README 또는 repo entry docs
+- 기본 결정: frontend GC는 repo-local npm scripts와 GitHub Actions가 소유한다. 기존 `lint/build` PR gate 위에 unused export/file/dependency detector를 추가하되, duplication scan과 wide cleanup은 scheduled sweep lane으로 분리한다. auto-generated cleanup PR은 lint autofix나 high-confidence unused code fix처럼 low-risk surface에만 제한한다.
+- 핵심 작업: repo-local GC scripts, PR blocking lane, scheduled sweep lane, cleanup candidate handoff, autofix boundary를 current frontend structure에 맞게 추가한다.
+- 비범위: backend repo 변경, workflow repo policy 재설계, high-risk refactor auto-merge
+- 산출물: frontend GC scripts/workflows/docs, `GRC-06` exec plan
+- 검증: PR gate command 통과, scheduled sweep report shape 확인, representative unused/duplication signal triage
 
 ## 참고
 


### PR DESCRIPTION
## Summary
- continuous quality feedback loop policy, quality sweep report template, quality-sweep-triage skill을 추가했습니다.
- workflow control plane과 backend/frontend repo-local GC runtime의 경계를 명시하고, 후속 rollout 기준을 roadmap과 work item catalog에 반영했습니다.

## Linked Issue
- Closes #60
- Related: 없음

## Approach
- 기존 failure-to-guardrail close-out loop와 분리된 recurring quality sweep policy를 정의했습니다.
- enterprise-grade harness 기준으로 `workflow = policy/triage`, `repo = detector/CI/runtime` 분리 원칙을 문서와 exec plan에 반영했습니다.
- 자동 cleanup PR은 low-risk autofix surface에만 허용하고, duplication refactor와 backend dead code removal은 issue-first를 기본으로 두었습니다.

## Review Guide
- `docs/operations/continuous-quality-feedback-loop.md`에서 trigger mode, signal taxonomy, lane 분리, disposition 규칙을 먼저 봐주세요.
- `docs/product/work-item-catalog.md`와 `docs/product/harness-roadmap.md`에서 `GRB-05`, `GRC-06` 후속 항목이 현재 boundary와 맞게 추가됐는지 확인해 주세요.
- `docs/exec-plans/active/2026-04-08-grw-23-continuous-quality-feedback-loop.md`의 enterprise review와 recommended rollout 판단이 문서 본문과 일치하는지 확인해 주세요.

## Validation
- operations/product/architecture/skill registry hook이 같은 vocabulary를 공유하는지 본문과 grep으로 확인했습니다.
- representative signal simulation으로 `coding-rule-drift -> cleanup-pr-candidate`, `unused-code-drift -> cleanup-pr-candidate` 분류 가능성을 점검했습니다.
- `git diff --check`를 통과했습니다.
- independent reviewer pool은 아직 실행하지 않았고, backend/frontend repo-local detector runtime도 이번 PR 범위에 포함하지 않았습니다.

## Dependencies / Impact
- 새 라이브러리, 외부 서비스, 스키마, 설정, 환경 변수, 마이그레이션: 없음
- 사용자나 운영에 영향이 있으면 적어 주세요: workflow control plane 문서와 skill vocabulary가 추가되어 후속 GC 작업의 기준이 됩니다.
- 배포, 롤백, 커뮤니케이션 시 주의점이 있으면 적어 주세요: 실제 GC detector와 automation runtime은 각 앱 repo 후속 작업으로 분리되어 있습니다.

## Risks / Follow-up
- 남아 있는 리스크: control plane만 추가된 상태라 실제 repo-local detector/CI runtime이 없으면 quality sweep은 운영 절차에 머뭅니다.
- 후속 작업이나 별도 Issue: `GRB-05` backend GC baseline 정렬, `GRC-06` frontend GC baseline 정렬, independent reviewer pool evidence 추가