### PR TITLE
[Task] GRW-S07 context-pack/boundary skill pack

### DIFF
--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -82,6 +82,8 @@
 - `request-intake`: 새 요청을 `대화`, `모호한 요청`, `즉시 실행 가능한 작업`으로 먼저 분류할 때 사용
 - `ambiguity-interview`: `모호한 요청`을 executable issue, `Blocked`, `Rejected` 중 하나로 수렴시킬 때 사용
 - `issue-to-exec-plan`: issue를 active exec plan으로 바꾸고 write scope와 verification을 잠글 때 사용
+- `context-pack-selection`: active exec plan 뒤에 primary context pack과 required docs, forbidden context를 잠글 때 사용
+- `boundary-check`: 구현 전에 read/write/network/escalation 경계와 write scope completeness를 다시 확인할 때 사용
 - `parallel-work-split`: 여러 agent를 투입하기 전에 ownership과 disjoint write set을 고정할 때 사용
 - `api-contract-sync`: backend API 계약 변화가 client consumer와 workflow evidence에 미치는 영향을 맞출 때 사용
 - `verification-contract-runner`: selected verification contract profile을 실행하고 latest verification report를 쓸 때 사용
@@ -103,7 +105,9 @@
 1. `request-intake`
 2. `ambiguity-interview` if route is `모호한 요청`
 3. `issue-to-exec-plan` if route is `즉시 실행 가능한 작업` or interview exits `Planned`
-4. `parallel-work-split` if more than one agent will work on the same issue
+4. `context-pack-selection` once active exec plan exists
+5. `boundary-check` before implementation
+6. `parallel-work-split` if more than one agent will work on the same issue
 
 아래 skill은 기본 진입 순서가 아니라 조건부 hook으로 사용한다.
 

--- a/.codex/skills/boundary-check/SKILL.md
+++ b/.codex/skills/boundary-check/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: boundary-check
+description: context pack selection 뒤에 task type별 read/write/network/escalation 경계와 exec plan의 write scope completeness를 다시 잠가야 할 때 사용한다. 구현 전에 scope drift, sibling repo write, broad escalation을 막는 점검 절차에 적용한다.
+---
+
+# Boundary Check
+
+이 skill의 목적은 더 넓은 접근을 정당화하는 것이 아니라, 지금 task가 이미 허용한 경계 안에서만 움직이도록 다시 확인하는 것이다.
+
+## 언제 사용하나
+
+- primary context pack이 정해졌고 구현 직전이다.
+- active exec plan에 write scope와 verification contract profile이 적혀 있다.
+- read/write/network/escalation 경계가 현재 task와 맞는지 다시 잠가야 한다.
+
+write scope가 비어 있거나 primary repo가 흔들리면 구현으로 가지 말고 exec plan 또는 planning으로 되돌린다.
+
+## 먼저 확인할 것
+
+- active exec plan
+- `docs/operations/tool-boundary-matrix.md`
+- `docs/operations/workflow-governance.md`
+- 필요하면 `docs/operations/verification-contract-registry.md`
+- selected primary context pack summary
+
+## 작업 방식
+
+1. primary repo와 task type이 여전히 하나인지 확인한다.
+2. 현재 읽으려는 문서와 파일이 selected context pack, issue, exec plan named input 안에 있는지 점검한다.
+3. allowed write paths, control-plane artifacts, explicitly forbidden path가 exec plan에 모두 적혀 있는지 확인한다.
+4. network 필요 여부를 `없음` 또는 목적 있는 외부 시스템으로 좁힌다.
+5. escalation trigger는 sandbox에서 막힌 필수 명령만 남기고 convenience escalation은 지운다.
+6. boundary conflict가 있으면 구현을 진행하지 말고 planning 갱신, scope 축소, `Blocked` 중 하나로 되돌린다.
+
+## 결과
+
+산출물은 boundary check summary다. 아래가 최소로 보여야 한다.
+
+- task type
+- read boundary
+- write boundary
+- control-plane artifact
+- explicitly forbidden path
+- network 필요 여부
+- escalation trigger
+- dangerous command no-go 또는 return signal
+
+## 빠른 점검 명령
+
+```bash
+sed -n '1,260p' docs/operations/tool-boundary-matrix.md
+sed -n '1,260p' docs/exec-plans/active/<plan>.md
+rg -n "Write Scope|Allowed write paths|Control-plane artifacts|Explicitly forbidden|Network / external systems|Escalation triggers" docs/exec-plans/active/<plan>.md
+sed -n '1,220p' docs/operations/workflow-governance.md
+```
+
+## 피해야 할 것
+
+- TODO, follow-up 메모, 사용자 한 줄 요청으로 write scope를 넓히지 않는다.
+- network를 default allow처럼 취급하지 않는다.
+- 더 좁은 대안이 있는데도 broad escalation을 요청하지 않는다.
+- 여러 저장소 구현을 현재 issue 하나에 묶지 않는다.
+- dangerous command를 필요성, 대상 경로, 대안 검토 없이 실행하지 않는다.

--- a/.codex/skills/context-pack-selection/SKILL.md
+++ b/.codex/skills/context-pack-selection/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: context-pack-selection
+description: active exec plan 뒤에 task type별 primary context pack을 고르고, required docs와 optional trigger와 forbidden context를 잠가야 할 때 사용한다. `workflow 문서 수정`, `backend 수정`, `frontend 수정`, `cross-repo planning` 중 하나로 시작 surface를 좁히고 eager load를 막는 작업에 적용한다.
+---
+
+# Context Pack Selection
+
+이 skill의 목적은 더 많은 문서를 읽는 것이 아니라, 지금 task에 필요한 최소 컨텍스트만 고정하는 것이다.
+
+## 언제 사용하나
+
+- active exec plan이 준비됐고 구현 전에 primary context pack을 정해야 한다.
+- task type은 이미 `workflow 문서 수정`, `backend 수정`, `frontend 수정`, `cross-repo planning` 중 하나로 좁혀졌다.
+- hot file 탐색을 시작하기 전에 required docs와 forbidden context를 먼저 잠가야 한다.
+
+primary repo나 task type이 아직 하나로 잠기지 않았다면 이 skill로 덮지 말고 planning으로 되돌린다.
+
+## 먼저 확인할 것
+
+- active exec plan
+- request record 또는 GitHub issue
+- `AGENTS.md`
+- `docs/README.md`
+- `PLANS.md`
+- `docs/operations/workflow-governance.md`
+- `docs/architecture/context-pack-registry.md`
+- workflow repo가 아닌 저장소가 primary면 target repo entry 문서
+
+## 작업 방식
+
+1. issue와 exec plan에서 primary repo와 task type이 하나로 잠겼는지 먼저 확인한다.
+2. `docs/architecture/context-pack-registry.md`의 mapping으로 primary context pack 하나를 고른다.
+3. common base context와 선택한 pack의 required docs만 먼저 연다.
+4. optional docs는 trigger와 함께 적고, forbidden context는 eager load 금지 surface로 분리한다.
+5. hot file 탐색은 issue noun과 write scope를 기준으로 시작하고 한 hop씩만 확장한다.
+6. 다른 pack의 required docs까지 필요해지거나 target repo entry 문서가 없으면 `Context Ready`를 선언하지 말고 planning 또는 `Blocked`로 되돌린다.
+
+## 결과
+
+산출물은 짧은 context selection summary다. 아래가 바로 보여야 한다.
+
+- primary repo
+- task type
+- primary context pack
+- required docs
+- optional docs trigger
+- forbidden context
+- first-ring hot file cue
+- stop signal 또는 planning return 조건
+
+## 빠른 점검 명령
+
+```bash
+sed -n '1,260p' docs/architecture/context-pack-registry.md
+sed -n '1,220p' docs/exec-plans/active/<plan>.md
+rg -n "<task type|repo name|issue noun>" docs .codex/skills
+sed -n '1,220p' <target-repo-entry-doc>
+```
+
+## 피해야 할 것
+
+- required docs를 잠그기 전에 sibling repo나 다른 pack의 문서를 먼저 열지 않는다.
+- optional docs를 default 읽기 목록처럼 취급하지 않는다.
+- 여러 pack의 required docs가 동시에 필요해졌는데 임의로 합치지 않는다.
+- target repo entry 문서나 공식 remote source 없이 `Context Ready`를 선언하지 않는다.
+- workflow 문서에 앱 동작 canonical source를 새로 복제하지 않는다.

--- a/docs/exec-plans/completed/2026-04-08-grw-s07-context-pack-boundary-skill-pack.md
+++ b/docs/exec-plans/completed/2026-04-08-grw-s07-context-pack-boundary-skill-pack.md
@@ -1,0 +1,156 @@
+# 2026-04-08-grw-s07-context-pack-boundary-skill-pack
+
+- Issue ID: `GRW-S07`
+- GitHub Issue: `#68`
+- Status: `Completed`
+- Repository: `git-ranker-workflow`
+- Branch Name: `feat/grw-s07-context-pack-boundary-skill-pack`
+- Task Slug: `2026-04-08-grw-s07-context-pack-boundary-skill-pack`
+- Primary Context Pack: `workflow-docs`
+- Verification Contract Profile: `workflow-docs`
+
+## Problem
+
+`GRW-13`에서 task type별 primary context pack, required docs, optional docs, forbidden context, hot file exploration 규칙이 source of truth로 고정됐다. `GRW-14`에서는 같은 task type 분류를 기준으로 read/write/network/escalation boundary와 write scope template까지 문서화됐다. 하지만 implementer가 실제 작업 착수 전에 이 두 문서를 같은 순서와 같은 stop signal로 재사용하게 만드는 project-local skill pack은 아직 없다.
+
+이 공백이 남아 있으면 같은 `workflow 문서 수정`, `backend 수정`, `frontend 수정`, `cross-repo planning` 작업도 누군가는 sibling repo를 먼저 열고, 누군가는 required docs 대신 optional docs를 먼저 읽고, 누군가는 write scope와 escalation trigger를 exec plan에 느슨하게 적는 drift가 생길 수 있다.
+
+## Why Now
+
+`GRW-S06`은 intake와 ambiguity narrowing을 operationalize했고, `GRW-S08`, `GRW-S09`는 verification 이후 close-out loop를 thin layer로 고정했다. implementer 단계 앞단에 해당하는 `Context Pack -> Boundary Check`가 빠져 있으면 Phase 2 skill pack은 시작과 종료만 있고, 실제 착수 조건을 잠그는 반복 절차가 비어 있게 된다.
+
+또한 `GRW-13`, `GRW-14` completed exec plan이 후속 자산으로 직접 `context-pack-selection`, `boundary-check` skill을 남겨 두었다. canonical policy는 이미 있으므로 이번 작업은 새 policy를 발명하는 것이 아니라, 그 규칙을 실제 구현 전에 재현하는 thin-layer skill 2종을 추가하는 데 집중한다.
+
+## Scope
+
+- `.codex/skills/context-pack-selection/SKILL.md` 작성
+- `.codex/skills/boundary-check/SKILL.md` 작성
+- `.codex/skills/README.md`에 새 skill registry와 recommended use hook 반영
+- `GRW-S07` exec plan 작성과 close-out 기록 정리
+
+## Non-scope
+
+- `docs/architecture/context-pack-registry.md` 또는 `docs/operations/tool-boundary-matrix.md`의 policy 재설계
+- backend/frontend 앱 코드 변경
+- 자동 context loader, runtime enforcement, sandbox 구현
+- verification/review/feedback skill 또는 policy 재작업
+- stable source of truth에 task ID를 설명용으로 추가하는 문서 개편
+
+## Write Scope
+
+- Primary repo: `git-ranker-workflow`
+- Allowed write paths:
+  - `.codex/skills/`
+  - `docs/exec-plans/`
+- Control-plane artifacts:
+  - `docs/exec-plans/active/2026-04-08-grw-s07-context-pack-boundary-skill-pack.md`
+  - `docs/exec-plans/completed/2026-04-08-grw-s07-context-pack-boundary-skill-pack.md`
+  - `/tmp/grw-s07-issue-body.md`
+- Explicitly forbidden:
+  - sibling app repo code tree
+  - `docs/architecture/`, `docs/operations/`, `docs/product/`의 policy 재설계
+  - scope 밖 stable source of truth mass update
+- Network / external systems:
+  - GitHub Issue create/view
+- Escalation triggers:
+  - 없음
+
+## Outputs
+
+- `.codex/skills/context-pack-selection/SKILL.md`
+- `.codex/skills/boundary-check/SKILL.md`
+- `.codex/skills/README.md`
+- `docs/exec-plans/completed/2026-04-08-grw-s07-context-pack-boundary-skill-pack.md`
+
+## Working Decisions
+
+- `context-pack-selection`은 `docs/architecture/context-pack-registry.md`를 canonical source로 두고, request/issue/exec plan에서 primary repo와 task type이 잠긴 뒤 required docs, optional trigger, forbidden context, hot file stop signal을 정리하는 역할만 맡는다.
+- `boundary-check`는 `docs/operations/tool-boundary-matrix.md`, `docs/operations/workflow-governance.md`, active exec plan의 write scope를 canonical source로 두고, read/write/network/escalation 경계와 write scope completeness를 다시 점검하는 역할만 맡는다.
+- 두 skill 모두 policy 표를 복사하지 않고, "무엇을 먼저 확인하고 어떤 경우에 planning 또는 blocker로 되돌릴지"를 얇은 workflow로만 제공한다.
+- `.codex/skills/README.md`에는 task ID가 아니라 asset 이름과 implementer 단계 hook만 반영한다.
+
+## Verification
+
+- `find .codex/skills -maxdepth 2 -type f | sort`
+  - 결과: `.codex/skills/context-pack-selection/SKILL.md`, `.codex/skills/boundary-check/SKILL.md`가 registry 아래 기대 경로에 추가된 것을 확인했다.
+- `sed -n '1,260p' .codex/skills/context-pack-selection/SKILL.md`
+  - 결과: primary repo/task type 잠금, single-pack selection, required docs, optional trigger, forbidden context, hot file stop signal이 포함된 것을 확인했다.
+- `sed -n '1,260p' .codex/skills/boundary-check/SKILL.md`
+  - 결과: read/write/network/escalation 경계, write scope completeness, convenience escalation 금지, boundary conflict return signal이 포함된 것을 확인했다.
+- `sed -n '1,260p' .codex/skills/README.md`
+  - 결과: 새 skill registry와 `issue-to-exec-plan -> context-pack-selection -> boundary-check` 추천 순서가 반영된 것을 확인했다.
+- `rg -n "context-pack-selection|boundary-check|workflow-docs|backend-change|frontend-change|cross-repo-planning|read boundary|write scope|forbidden context|escalation" .codex/skills docs/architecture docs/operations`
+  - 결과: skill 본문과 canonical source가 `workflow-docs`, `backend-change`, `frontend-change`, `cross-repo-planning`, read/write boundary, forbidden context, escalation vocabulary를 함께 재사용하는 것을 확인했다.
+- representative task 수동 시뮬레이션 2건
+  - 결과: "하네스 정책 문서를 정리한다" surface는 `workflow-docs` pack과 workflow-only write boundary로, "backend verification command를 정리한다" surface는 `backend-change` pack과 backend-only write boundary로 각각 좁혀져 두 skill의 역할 분리가 유지되는 것을 확인했다.
+- `gh issue view --repo alexization/git-ranker-workflow 68 --json body,title,number`
+  - 결과: Issue `#68` 본문이 템플릿 섹션과 줄바꿈을 유지한 채 생성된 것을 확인했다.
+- `git diff --check`
+  - 결과: whitespace 또는 patch formatting 오류가 없음을 확인했다.
+
+## Verification Report
+
+- Contract profile: `workflow-docs`
+- Overall status: `passed`
+- Preconditions:
+  - workflow 저장소의 skill/doc 전용 변경
+  - GitHub Issue `#68`, feature branch, exec plan이 준비됨
+- Command: `find .codex/skills -maxdepth 2 -type f | sort`
+  - Status: `passed`
+  - Evidence: 새 skill 2종이 기대 경로에 추가됐다.
+- Command: `sed -n '1,260p' .codex/skills/context-pack-selection/SKILL.md`
+  - Status: `passed`
+  - Evidence: primary pack selection, required/optional/forbidden context, stop signal이 포함됐다.
+- Command: `sed -n '1,260p' .codex/skills/boundary-check/SKILL.md`
+  - Status: `passed`
+  - Evidence: read/write/network/escalation boundary와 write scope completeness 점검이 포함됐다.
+- Command: `sed -n '1,260p' .codex/skills/README.md`
+  - Status: `passed`
+  - Evidence: registry와 recommended use가 새 implementer-start hook을 반영한다.
+- Command: `rg -n "context-pack-selection|boundary-check|workflow-docs|backend-change|frontend-change|cross-repo-planning|read boundary|write scope|forbidden context|escalation" .codex/skills docs/architecture docs/operations`
+  - Status: `passed`
+  - Evidence: 새 skill과 canonical source가 같은 vocabulary와 hook을 공유한다.
+- Command: `gh issue view --repo alexization/git-ranker-workflow 68 --json body,title,number`
+  - Status: `passed`
+  - Evidence: Issue `#68` 본문이 기대한 섹션과 줄바꿈을 유지한다.
+- Command: `git diff --check`
+  - Status: `passed`
+  - Evidence: formatting 오류가 없다.
+- Failure summary: 없음
+- Next action: `Context Pack -> Boundary Check` handoff를 pilot 또는 repo-specific task에서 재사용
+
+## Evidence
+
+- skill 본문 2종
+- registry 업데이트 결과
+- representative task simulation 메모
+- GitHub Issue `#68` body 확인 결과
+- `git diff --check` 결과
+
+## Independent Review
+
+- Not run
+- Reason: 이번 턴은 로컬 skill authoring과 close-out 정리까지만 범위에 포함했고, session-isolated reviewer pool handoff는 별도 요청하지 않았다.
+
+## Risks or Blockers
+
+- skill이 context pack registry나 tool boundary matrix를 과도하게 재서술하면 source of truth drift가 생길 수 있다.
+- `context-pack-selection`과 `boundary-check`의 책임이 겹치면 planning/implementation 경계가 다시 흐려질 수 있다.
+- repo-specific 예시를 너무 많이 넣으면 thin-layer skill보다 mini policy 복제가 될 수 있다.
+- 실제 runtime에서의 재사용성은 `GRW-18` pilot이나 repo-specific task에서 다시 검증해야 한다.
+
+## Next Preconditions
+
+- `GRW-18`: workflow repo pilot issue로 새 흐름 1회 검증
+- repo-specific 구현 작업에서 `Context Pack -> Boundary Check` handoff를 실제로 재사용
+
+## Docs Updated
+
+- `.codex/skills/context-pack-selection/SKILL.md`
+- `.codex/skills/boundary-check/SKILL.md`
+- `.codex/skills/README.md`
+- `docs/exec-plans/completed/2026-04-08-grw-s07-context-pack-boundary-skill-pack.md`
+
+## Skill Consideration
+
+이번 Issue 자체가 implementer 시작 단계 thin-layer skill pack을 추가하는 작업이다. 새 skill은 policy를 대체하지 않고, context selection과 boundary check를 같은 입력/출력/증거 규칙으로 재사용하게 만드는 실행 레시피에 집중한다.


### PR DESCRIPTION
## Summary
- `context-pack-selection`, `boundary-check` project-local skill 2종을 추가했습니다.
- implementer가 `issue-to-exec-plan` 뒤에 primary context pack과 read/write/network/escalation 경계를 같은 순서로 잠글 수 있게 했습니다.

## Linked Issue
- Closes #68
- Related: #35, #37

## Approach
- canonical source는 계속 `docs/architecture/context-pack-registry.md`, `docs/operations/tool-boundary-matrix.md`, `docs/operations/workflow-governance.md`에 두고, 이번 PR은 그 규칙을 얇게 operationalize하는 skill layer만 추가했습니다.
- `context-pack-selection`은 pack 선택, required/optional/forbidden context, hot file stop signal만 맡기고, `boundary-check`는 read/write/network/escalation 경계와 write scope completeness 재확인만 맡도록 책임을 분리했습니다.
- skills registry와 completed exec plan을 함께 갱신해 implementer 시작 단계 hook과 verification evidence를 한 surface에 남겼습니다.

## Review Guide
- `.codex/skills/context-pack-selection/SKILL.md`가 single-pack selection과 eager-load 금지 규칙을 source of truth drift 없이 재사용하는지 먼저 봐 주세요.
- `.codex/skills/boundary-check/SKILL.md`가 write scope completeness, network 필요 여부, escalation trigger를 tool-boundary matrix와 같은 어휘로 좁히는지 확인해 주세요.
- `docs/exec-plans/completed/2026-04-08-grw-s07-context-pack-boundary-skill-pack.md`의 verification report와 scope/non-scope가 실제 diff와 일치하는지 봐 주세요.

## Validation
- skill 경로 생성 확인, 두 SKILL 본문 점검, skills registry 반영, canonical hook grep, issue body render 확인, `git diff --check`까지 통과했습니다.
- representative simulation으로 `workflow-docs`와 `backend-change` surface에서 두 skill의 역할 분리가 유지되는지 점검했습니다.
- session-isolated independent review는 이번 브랜치에서 아직 실행하지 않았습니다.

## Dependencies / Impact
- 새 라이브러리, 외부 서비스, 스키마, 설정, 환경 변수, 마이그레이션: 없음
- 사용자나 운영에 영향이 있으면 적어 주세요: workflow 저장소의 implementer 시작 단계 skill 순서가 `issue-to-exec-plan -> context-pack-selection -> boundary-check`로 구체화됩니다.
- 배포, 롤백, 커뮤니케이션 시 주의점이 있으면 적어 주세요: 없음

## Risks / Follow-up
- 남아 있는 리스크: 실제 runtime에서의 재사용성은 pilot이나 repo-specific task에서 다시 확인해야 합니다.
- 후속 작업이나 별도 Issue: `GRW-18` pilot에서 `Context Pack -> Boundary Check` handoff를 실제로 재사용
