### PR TITLE
chore: git-ranker core loop unit test task artifact publish

### DIFF
--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/phases.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/phases.json
@@ -1,0 +1,126 @@
+{
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "generated_at": "2026-04-16T05:48:14+00:00",
+  "phases": [
+    {
+      "id": "phase-1",
+      "title": "existing-tests-and-domain-core",
+      "goal": "Harden existing unit tests and add detailed value/domain/orchestrator coverage for the core feedback loop without expanding beyond narrow unit tests.",
+      "inputs": [
+        "workflows/tasks/task-gitranker-core-loop-unit-tests/spec.md",
+        "git-ranker/AGENTS.md",
+        "git-ranker/src/main/java/com/gitranker/api/domain/",
+        "git-ranker/src/test/java/"
+      ],
+      "allowed_write_paths": [
+        "git-ranker/src/test/java/"
+      ],
+      "acceptance": {
+        "commands": [
+          "cd git-ranker && ./gradlew test --tests 'com.gitranker.api.domain.auth.service.*' --tests 'com.gitranker.api.domain.badge.*' --tests 'com.gitranker.api.domain.log.*' --tests 'com.gitranker.api.domain.ranking.*' --tests 'com.gitranker.api.domain.user.*' --tests 'com.gitranker.api.global.util.*'"
+        ]
+      },
+      "test_policy": {
+        "mode": "require_tests",
+        "evidence": []
+      },
+      "order": 1,
+      "status": "completed",
+      "retry_count": 1,
+      "required_reads": [
+        "workflows/tasks/task-gitranker-core-loop-unit-tests/spec.md",
+        "git-ranker/AGENTS.md",
+        "git-ranker/src/main/java/com/gitranker/api/domain/",
+        "git-ranker/src/test/java/"
+      ],
+      "starting_points": [
+        "Read the locked spec for task-gitranker-core-loop-unit-tests.",
+        "Inspect the active phase goal: Harden existing unit tests and add detailed value/domain/orchestrator coverage for the core feedback loop without expanding beyond narrow unit tests.",
+        "Confirm allowed write paths and acceptance commands before editing."
+      ],
+      "deliverables": [
+        "Harden existing unit tests and add detailed value/domain/orchestrator coverage for the core feedback loop without expanding beyond narrow unit tests."
+      ],
+      "completion_signal": "phase-1 acceptance commands pass"
+    },
+    {
+      "id": "phase-2",
+      "title": "batch-feedback-loop-tests",
+      "goal": "Add fine-grained batch feedback and verification loop unit tests covering boundary cases, skip/retry/error translation, and side effects.",
+      "inputs": [
+        "workflows/tasks/task-gitranker-core-loop-unit-tests/spec.md",
+        "git-ranker/src/main/java/com/gitranker/api/batch/",
+        "git-ranker/src/test/java/"
+      ],
+      "allowed_write_paths": [
+        "git-ranker/src/test/java/"
+      ],
+      "acceptance": {
+        "commands": [
+          "cd git-ranker && ./gradlew test --tests 'com.gitranker.api.batch.*'"
+        ]
+      },
+      "test_policy": {
+        "mode": "require_tests",
+        "evidence": []
+      },
+      "order": 2,
+      "status": "completed",
+      "retry_count": 1,
+      "required_reads": [
+        "workflows/tasks/task-gitranker-core-loop-unit-tests/spec.md",
+        "git-ranker/src/main/java/com/gitranker/api/batch/",
+        "git-ranker/src/test/java/"
+      ],
+      "starting_points": [
+        "Read the locked spec for task-gitranker-core-loop-unit-tests.",
+        "Inspect the active phase goal: Add fine-grained batch feedback and verification loop unit tests covering boundary cases, skip/retry/error translation, and side effects.",
+        "Confirm allowed write paths and acceptance commands before editing."
+      ],
+      "deliverables": [
+        "Add fine-grained batch feedback and verification loop unit tests covering boundary cases, skip/retry/error translation, and side effects."
+      ],
+      "completion_signal": "phase-2 acceptance commands pass"
+    },
+    {
+      "id": "phase-3",
+      "title": "github-infra-and-full-suite",
+      "goal": "Add exhaustive GitHub collection and error translation unit tests, then confirm the full git-ranker unit-test baseline stays green.",
+      "inputs": [
+        "workflows/tasks/task-gitranker-core-loop-unit-tests/spec.md",
+        "git-ranker/src/main/java/com/gitranker/api/infrastructure/github/",
+        "git-ranker/src/test/java/"
+      ],
+      "allowed_write_paths": [
+        "git-ranker/src/test/java/"
+      ],
+      "acceptance": {
+        "commands": [
+          "cd git-ranker && ./gradlew test --tests 'com.gitranker.api.infrastructure.github.*'",
+          "cd git-ranker && ./gradlew test"
+        ]
+      },
+      "test_policy": {
+        "mode": "require_tests",
+        "evidence": []
+      },
+      "order": 3,
+      "status": "completed",
+      "retry_count": 2,
+      "required_reads": [
+        "workflows/tasks/task-gitranker-core-loop-unit-tests/spec.md",
+        "git-ranker/src/main/java/com/gitranker/api/infrastructure/github/",
+        "git-ranker/src/test/java/"
+      ],
+      "starting_points": [
+        "Read the locked spec for task-gitranker-core-loop-unit-tests.",
+        "Inspect the active phase goal: Add exhaustive GitHub collection and error translation unit tests, then confirm the full git-ranker unit-test baseline stays green.",
+        "Confirm allowed write paths and acceptance commands before editing."
+      ],
+      "deliverables": [
+        "Add exhaustive GitHub collection and error translation unit tests, then confirm the full git-ranker unit-test baseline stays green."
+      ],
+      "completion_signal": "phase-3 acceptance commands pass"
+    }
+  ]
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T055405-c7b7c277.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T055405-c7b7c277.json
@@ -1,0 +1,20 @@
+{
+  "id": "20260416T055405-c7b7c277",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-1",
+  "event": "phase_completion",
+  "commands": [
+    {
+      "command": "phase completion",
+      "status": "passed",
+      "output": "git-ranker/src/test/java/com/gitranker/api/domain/auth/service/AuthServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/badge/BadgeFormatterTest.java, git-ranker/src/test/java/com/gitranker/api/domain/badge/BadgeServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/badge/SvgBadgeRendererTest.java, git-ranker/src/test/java/com/gitranker/api/domain/log/ActivityLogOrchestratorTest.java, git-ranker/src/test/java/com/gitranker/api/domain/log/ActivityLogServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/log/ActivityLogTest.java, git-ranker/src/test/java/com/gitranker/api/domain/ranking/RankingRecalculationServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/ranking/RankingServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/user/UserTest.java, git-ranker/src/test/java/com/gitranker/api/domain/user/service/UserDeletionServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/user/service/UserPersistenceServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/user/service/UserQueryServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/user/service/UserRefreshServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/user/service/UserRegistrationServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/user/vo/ActivityStatisticsTest.java, git-ranker/src/test/java/com/gitranker/api/domain/user/vo/RankInfoTest.java, git-ranker/src/test/java/com/gitranker/api/domain/user/vo/ScoreTest.java, git-ranker/src/test/java/com/gitranker/api/global/util/TimeUtilsTest.java"
+    }
+  ],
+  "result": "passed",
+  "evidence": [
+    "Added domain/value/orchestrator tests and hardened existing unit tests for error, fallback, boundary, and side-effect coverage."
+  ],
+  "error_fingerprint": null,
+  "next_action": "verify",
+  "timestamp": "2026-04-16T05:54:05+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T055409-7d0a28cb.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T055409-7d0a28cb.json
@@ -1,0 +1,18 @@
+{
+  "id": "20260416T055409-7d0a28cb",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-1",
+  "event": "verification",
+  "commands": [
+    {
+      "command": "cd git-ranker && ./gradlew test --tests 'com.gitranker.api.domain.auth.service.*' --tests 'com.gitranker.api.domain.badge.*' --tests 'com.gitranker.api.domain.log.*' --tests 'com.gitranker.api.domain.ranking.*' --tests 'com.gitranker.api.domain.user.*' --tests 'com.gitranker.api.global.util.*'",
+      "status": "failed",
+      "output": "Exception in thread \"main\" java.io.FileNotFoundException: /Users/hyoseok/.gradle/wrapper/dists/gradle-9.2.1-bin/2t0n5ozlw9xmuyvbp7dnzaxug/gradle-9.2.1-bin.zip.lck (Operation not permitted)\n\tat java.base/java.io.RandomAccessFile.open0(Native Method)\n\tat java.base/java.io.RandomAccessFile.open(RandomAccessFile.java:338)\n\tat java.base/java.io.RandomAccessFile.<init>(RandomAccessFile.java:257)\n\tat java.base/java.io.RandomAccessFile.<init>(RandomAccessFile.java:211)\n\tat org.gradle.wrapper.GradleWrapperMain.main(SourceFile:67)"
+    }
+  ],
+  "result": "failed",
+  "evidence": [],
+  "error_fingerprint": "verification:phase-1:cd git-ranker && ./gradlew test --tests 'com.gitranker.api.domain.auth.service.*' --tests 'com.gitranker.api.domain.badge.*' --tests 'com.gitranker.api.domain.log.*' --tests 'com.gitranker.api.domain.ranking.*' --tests 'com.gitranker.api.domain.user.*' --tests 'com.gitranker.api.global.util.*'",
+  "next_action": "repair",
+  "timestamp": "2026-04-16T05:54:09+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T055443-161dc9a6.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T055443-161dc9a6.json
@@ -1,0 +1,20 @@
+{
+  "id": "20260416T055443-161dc9a6",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-1",
+  "event": "reopened",
+  "commands": [
+    {
+      "command": "reopen task",
+      "status": "passed",
+      "output": "Verification failed due to sandbox-denied Gradle lock file access; reopen phase to rerun verification with escalated permissions."
+    }
+  ],
+  "result": "passed",
+  "evidence": [
+    "Verification failed due to sandbox-denied Gradle lock file access; reopen phase to rerun verification with escalated permissions."
+  ],
+  "error_fingerprint": null,
+  "next_action": "plan or run",
+  "timestamp": "2026-04-16T05:54:43+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T055503-5f5a11e6.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T055503-5f5a11e6.json
@@ -1,0 +1,20 @@
+{
+  "id": "20260416T055503-5f5a11e6",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-1",
+  "event": "phase_completion",
+  "commands": [
+    {
+      "command": "phase completion",
+      "status": "passed",
+      "output": "git-ranker/src/test/java/com/gitranker/api/domain/auth/service/AuthServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/badge/BadgeFormatterTest.java, git-ranker/src/test/java/com/gitranker/api/domain/badge/BadgeServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/badge/SvgBadgeRendererTest.java, git-ranker/src/test/java/com/gitranker/api/domain/log/ActivityLogOrchestratorTest.java, git-ranker/src/test/java/com/gitranker/api/domain/log/ActivityLogServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/log/ActivityLogTest.java, git-ranker/src/test/java/com/gitranker/api/domain/ranking/RankingRecalculationServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/ranking/RankingServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/user/UserTest.java, git-ranker/src/test/java/com/gitranker/api/domain/user/service/UserDeletionServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/user/service/UserPersistenceServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/user/service/UserQueryServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/user/service/UserRefreshServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/user/service/UserRegistrationServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/user/vo/ActivityStatisticsTest.java, git-ranker/src/test/java/com/gitranker/api/domain/user/vo/RankInfoTest.java, git-ranker/src/test/java/com/gitranker/api/domain/user/vo/ScoreTest.java, git-ranker/src/test/java/com/gitranker/api/global/util/TimeUtilsTest.java"
+    }
+  ],
+  "result": "passed",
+  "evidence": [
+    "Reclosed phase-1 after sandbox-related verification repair; code/test changes unchanged."
+  ],
+  "error_fingerprint": null,
+  "next_action": "verify",
+  "timestamp": "2026-04-16T05:55:03+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T055523-6d34b7f8.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T055523-6d34b7f8.json
@@ -1,0 +1,18 @@
+{
+  "id": "20260416T055523-6d34b7f8",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-1",
+  "event": "verification",
+  "commands": [
+    {
+      "command": "cd git-ranker && ./gradlew test --tests 'com.gitranker.api.domain.auth.service.*' --tests 'com.gitranker.api.domain.badge.*' --tests 'com.gitranker.api.domain.log.*' --tests 'com.gitranker.api.domain.ranking.*' --tests 'com.gitranker.api.domain.user.*' --tests 'com.gitranker.api.global.util.*'",
+      "status": "passed",
+      "output": "Starting a Gradle Daemon, 1 incompatible Daemon could not be reused, use --status for details\n> Task :compileJava UP-TO-DATE\n> Task :processResources UP-TO-DATE\n> Task :classes UP-TO-DATE\n> Task :compileTestJava UP-TO-DATE\n> Task :processTestResources NO-SOURCE\n> Task :testClasses UP-TO-DATE\n> Task :test UP-TO-DATE\n\nBUILD SUCCESSFUL in 4s\n4 actionable tasks: 4 up-to-date\nConsider enabling configuration cache to speed up this build: https://docs.gradle.org/9.2.1/userguide/configuration_cache_enabling.html"
+    }
+  ],
+  "result": "passed",
+  "evidence": [],
+  "error_fingerprint": null,
+  "next_action": "review",
+  "timestamp": "2026-04-16T05:55:23+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T060406-fb8e67a9.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T060406-fb8e67a9.json
@@ -1,0 +1,18 @@
+{
+  "id": "20260416T060406-fb8e67a9",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-2",
+  "event": "phase_completion",
+  "commands": [
+    {
+      "command": "phase completion",
+      "status": "passed",
+      "output": "git-ranker/src/test/java/com/gitranker/api/batch/listener/BatchProgressListenerTest.java, git-ranker/src/test/java/com/gitranker/api/batch/listener/GitHubCostListenerTest.java, git-ranker/src/test/java/com/gitranker/api/batch/listener/UserScoreCalculationSkipListenerTest.java, git-ranker/src/test/java/com/gitranker/api/batch/metrics/BatchMetricsTest.java, git-ranker/src/test/java/com/gitranker/api/batch/processor/ScoreRecalculationProcessorTest.java, git-ranker/src/test/java/com/gitranker/api/batch/reader/UserItemReaderTest.java, git-ranker/src/test/java/com/gitranker/api/batch/scheduler/BatchSchedulerTest.java, git-ranker/src/test/java/com/gitranker/api/batch/strategy/ActivityUpdateContextTest.java, git-ranker/src/test/java/com/gitranker/api/batch/strategy/FullActivityUpdateStrategyTest.java, git-ranker/src/test/java/com/gitranker/api/batch/strategy/IncrementalActivityUpdateStrategyTest.java, git-ranker/src/test/java/com/gitranker/api/batch/tasklet/RankingRecalculationTaskletTest.java, git-ranker/src/test/java/com/gitranker/api/batch/writer/UserItemWriterTest.java"
+    }
+  ],
+  "result": "passed",
+  "evidence": [],
+  "error_fingerprint": null,
+  "next_action": "verify",
+  "timestamp": "2026-04-16T06:04:06+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T060409-cd1b0372.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T060409-cd1b0372.json
@@ -1,0 +1,18 @@
+{
+  "id": "20260416T060409-cd1b0372",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-2",
+  "event": "verification",
+  "commands": [
+    {
+      "command": "cd git-ranker && ./gradlew test --tests 'com.gitranker.api.batch.*'",
+      "status": "failed",
+      "output": "Exception in thread \"main\" java.io.FileNotFoundException: /Users/hyoseok/.gradle/wrapper/dists/gradle-9.2.1-bin/2t0n5ozlw9xmuyvbp7dnzaxug/gradle-9.2.1-bin.zip.lck (Operation not permitted)\n\tat java.base/java.io.RandomAccessFile.open0(Native Method)\n\tat java.base/java.io.RandomAccessFile.open(RandomAccessFile.java:338)\n\tat java.base/java.io.RandomAccessFile.<init>(RandomAccessFile.java:257)\n\tat java.base/java.io.RandomAccessFile.<init>(RandomAccessFile.java:211)\n\tat org.gradle.wrapper.GradleWrapperMain.main(SourceFile:67)"
+    }
+  ],
+  "result": "failed",
+  "evidence": [],
+  "error_fingerprint": "verification:phase-2:cd git-ranker && ./gradlew test --tests 'com.gitranker.api.batch.*'",
+  "next_action": "repair",
+  "timestamp": "2026-04-16T06:04:09+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T060425-5d5d570b.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T060425-5d5d570b.json
@@ -1,0 +1,20 @@
+{
+  "id": "20260416T060425-5d5d570b",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-2",
+  "event": "reopened",
+  "commands": [
+    {
+      "command": "reopen task",
+      "status": "passed",
+      "output": "Verification failed due to sandbox-denied Gradle wrapper lock access; reopen phase to rerun verification with escalated permissions."
+    }
+  ],
+  "result": "passed",
+  "evidence": [
+    "Verification failed due to sandbox-denied Gradle wrapper lock access; reopen phase to rerun verification with escalated permissions."
+  ],
+  "error_fingerprint": null,
+  "next_action": "plan or run",
+  "timestamp": "2026-04-16T06:04:25+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T060435-a977ad16.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T060435-a977ad16.json
@@ -1,0 +1,18 @@
+{
+  "id": "20260416T060435-a977ad16",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-2",
+  "event": "phase_completion",
+  "commands": [
+    {
+      "command": "phase completion",
+      "status": "passed",
+      "output": "git-ranker/src/test/java/com/gitranker/api/batch/listener/BatchProgressListenerTest.java, git-ranker/src/test/java/com/gitranker/api/batch/listener/GitHubCostListenerTest.java, git-ranker/src/test/java/com/gitranker/api/batch/listener/UserScoreCalculationSkipListenerTest.java, git-ranker/src/test/java/com/gitranker/api/batch/metrics/BatchMetricsTest.java, git-ranker/src/test/java/com/gitranker/api/batch/processor/ScoreRecalculationProcessorTest.java, git-ranker/src/test/java/com/gitranker/api/batch/reader/UserItemReaderTest.java, git-ranker/src/test/java/com/gitranker/api/batch/scheduler/BatchSchedulerTest.java, git-ranker/src/test/java/com/gitranker/api/batch/strategy/ActivityUpdateContextTest.java, git-ranker/src/test/java/com/gitranker/api/batch/strategy/FullActivityUpdateStrategyTest.java, git-ranker/src/test/java/com/gitranker/api/batch/strategy/IncrementalActivityUpdateStrategyTest.java, git-ranker/src/test/java/com/gitranker/api/batch/tasklet/RankingRecalculationTaskletTest.java, git-ranker/src/test/java/com/gitranker/api/batch/writer/UserItemWriterTest.java"
+    }
+  ],
+  "result": "passed",
+  "evidence": [],
+  "error_fingerprint": null,
+  "next_action": "verify",
+  "timestamp": "2026-04-16T06:04:35+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T060618-dd774817.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T060618-dd774817.json
@@ -1,0 +1,18 @@
+{
+  "id": "20260416T060618-dd774817",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-2",
+  "event": "verification",
+  "commands": [
+    {
+      "command": "cd git-ranker && ./gradlew test --tests 'com.gitranker.api.batch.*'",
+      "status": "passed",
+      "output": "> Task :compileJava UP-TO-DATE\n> Task :processResources UP-TO-DATE\n> Task :classes UP-TO-DATE\n> Task :compileTestJava UP-TO-DATE\n> Task :processTestResources NO-SOURCE\n> Task :testClasses UP-TO-DATE\n> Task :test UP-TO-DATE\n\nBUILD SUCCESSFUL in 1s\n4 actionable tasks: 4 up-to-date\nConsider enabling configuration cache to speed up this build: https://docs.gradle.org/9.2.1/userguide/configuration_cache_enabling.html"
+    }
+  ],
+  "result": "passed",
+  "evidence": [],
+  "error_fingerprint": null,
+  "next_action": "review",
+  "timestamp": "2026-04-16T06:06:18+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T061059-edeb1748.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T061059-edeb1748.json
@@ -1,0 +1,18 @@
+{
+  "id": "20260416T061059-edeb1748",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-3",
+  "event": "phase_completion",
+  "commands": [
+    {
+      "command": "phase completion",
+      "status": "passed",
+      "output": "git-ranker/src/test/java/com/gitranker/api/infrastructure/github/GitHubActivityServiceTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/GitHubApiErrorHandlerTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/GitHubApiMetricsTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/GitHubDataMapperTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/GitHubGraphQLClientTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/dto/GitHubActivitySummaryTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/dto/GitHubAllActivitiesResponseTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/dto/GitHubGraphQLRequestTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/dto/GitHubNodeUserResponseTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/dto/GitHubUserInfoResponseTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/token/GitHubTokenPoolTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/token/TokenStateTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/util/GraphQLQueryBuilderTest.java"
+    }
+  ],
+  "result": "passed",
+  "evidence": [],
+  "error_fingerprint": null,
+  "next_action": "verify",
+  "timestamp": "2026-04-16T06:10:59+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T061201-60068c66.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T061201-60068c66.json
@@ -1,0 +1,23 @@
+{
+  "id": "20260416T061201-60068c66",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-3",
+  "event": "verification",
+  "commands": [
+    {
+      "command": "cd git-ranker && ./gradlew test --tests 'com.gitranker.api.infrastructure.github.*'",
+      "status": "passed",
+      "output": "> Task :compileJava UP-TO-DATE\n> Task :processResources UP-TO-DATE\n> Task :classes UP-TO-DATE\n> Task :compileTestJava UP-TO-DATE\n> Task :processTestResources NO-SOURCE\n> Task :testClasses UP-TO-DATE\n> Task :test\n\nBUILD SUCCESSFUL in 2s\n4 actionable tasks: 1 executed, 3 up-to-date\nConsider enabling configuration cache to speed up this build: https://docs.gradle.org/9.2.1/userguide/configuration_cache_enabling.html\n\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended"
+    },
+    {
+      "command": "cd git-ranker && ./gradlew test",
+      "status": "failed",
+      "output": "> Task :compileJava UP-TO-DATE\n> Task :processResources UP-TO-DATE\n> Task :classes UP-TO-DATE\n> Task :compileTestJava UP-TO-DATE\n> Task :processTestResources NO-SOURCE\n> Task :testClasses UP-TO-DATE\n\n> Task :test FAILED\n\nGitHubGraphQLClientTest > getAllActivities merges merged-pr block and yearly contribution response FAILED\n    org.mockito.exceptions.verification.opentest4j.ArgumentsAreDifferent at GitHubGraphQLClientTest.java:172\n4 actionable tasks: 1 executed, 3 up-to-date\n\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has be..."
+    }
+  ],
+  "result": "failed",
+  "evidence": [],
+  "error_fingerprint": "verification:phase-3:cd git-ranker && ./gradlew test",
+  "next_action": "repair",
+  "timestamp": "2026-04-16T06:12:01+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T061240-118f07df.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T061240-118f07df.json
@@ -1,0 +1,20 @@
+{
+  "id": "20260416T061240-118f07df",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-3",
+  "event": "reopened",
+  "commands": [
+    {
+      "command": "reopen task",
+      "status": "passed",
+      "output": "Verification exposed a nondeterministic full-suite assertion in GitHubGraphQLClientTest; reopen phase after fixing the test to rerun final verification."
+    }
+  ],
+  "result": "passed",
+  "evidence": [
+    "Verification exposed a nondeterministic full-suite assertion in GitHubGraphQLClientTest; reopen phase after fixing the test to rerun final verification."
+  ],
+  "error_fingerprint": null,
+  "next_action": "plan or run",
+  "timestamp": "2026-04-16T06:12:40+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T061249-83c3d5da.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T061249-83c3d5da.json
@@ -1,0 +1,18 @@
+{
+  "id": "20260416T061249-83c3d5da",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-3",
+  "event": "phase_completion",
+  "commands": [
+    {
+      "command": "phase completion",
+      "status": "passed",
+      "output": "git-ranker/src/test/java/com/gitranker/api/infrastructure/github/GitHubActivityServiceTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/GitHubApiErrorHandlerTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/GitHubApiMetricsTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/GitHubDataMapperTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/GitHubGraphQLClientTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/dto/GitHubActivitySummaryTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/dto/GitHubAllActivitiesResponseTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/dto/GitHubGraphQLRequestTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/dto/GitHubNodeUserResponseTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/dto/GitHubUserInfoResponseTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/token/GitHubTokenPoolTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/token/TokenStateTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/util/GraphQLQueryBuilderTest.java"
+    }
+  ],
+  "result": "passed",
+  "evidence": [],
+  "error_fingerprint": null,
+  "next_action": "verify",
+  "timestamp": "2026-04-16T06:12:49+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T061306-e0472a6c.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T061306-e0472a6c.json
@@ -1,0 +1,23 @@
+{
+  "id": "20260416T061306-e0472a6c",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-3",
+  "event": "verification",
+  "commands": [
+    {
+      "command": "cd git-ranker && ./gradlew test --tests 'com.gitranker.api.infrastructure.github.*'",
+      "status": "passed",
+      "output": "> Task :compileJava UP-TO-DATE\n> Task :processResources UP-TO-DATE\n> Task :classes UP-TO-DATE\n> Task :compileTestJava UP-TO-DATE\n> Task :processTestResources NO-SOURCE\n> Task :testClasses UP-TO-DATE\n> Task :test\n\nBUILD SUCCESSFUL in 2s\n4 actionable tasks: 1 executed, 3 up-to-date\nConsider enabling configuration cache to speed up this build: https://docs.gradle.org/9.2.1/userguide/configuration_cache_enabling.html\n\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended"
+    },
+    {
+      "command": "cd git-ranker && ./gradlew test",
+      "status": "passed",
+      "output": "> Task :compileJava UP-TO-DATE\n> Task :processResources UP-TO-DATE\n> Task :classes UP-TO-DATE\n> Task :compileTestJava UP-TO-DATE\n> Task :processTestResources NO-SOURCE\n> Task :testClasses UP-TO-DATE\n> Task :test\n\nBUILD SUCCESSFUL in 2s\n4 actionable tasks: 1 executed, 3 up-to-date\nConsider enabling configuration cache to speed up this build: https://docs.gradle.org/9.2.1/userguide/configuration_cache_enabling.html\n\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended"
+    }
+  ],
+  "result": "passed",
+  "evidence": [],
+  "error_fingerprint": null,
+  "next_action": "review",
+  "timestamp": "2026-04-16T06:13:06+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T061313-90ee609a.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T061313-90ee609a.json
@@ -1,0 +1,20 @@
+{
+  "id": "20260416T061313-90ee609a",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-3",
+  "event": "review_ready",
+  "commands": [
+    {
+      "command": "review gate",
+      "status": "passed",
+      "output": "latest passed verification: 20260416T061306-e0472a6c"
+    }
+  ],
+  "result": "passed",
+  "evidence": [
+    "All planned domain, batch, and GitHub unit-test phases passed their acceptance commands including final ./gradlew test."
+  ],
+  "error_fingerprint": null,
+  "next_action": "user validation",
+  "timestamp": "2026-04-16T06:13:13+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T061953-5dcd9c28.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T061953-5dcd9c28.json
@@ -1,0 +1,20 @@
+{
+  "id": "20260416T061953-5dcd9c28",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-3",
+  "event": "review_closeout",
+  "commands": [
+    {
+      "command": "complete task",
+      "status": "passed",
+      "output": "사용자가 테스트 보강 결과를 검증 완료로 확인하고 workflow closeout 진행을 요청함"
+    }
+  ],
+  "result": "passed",
+  "evidence": [
+    "사용자가 테스트 보강 결과를 검증 완료로 확인하고 workflow closeout 진행을 요청함"
+  ],
+  "error_fingerprint": null,
+  "next_action": "done",
+  "timestamp": "2026-04-16T06:19:53+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T074913-4422cb24.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T074913-4422cb24.json
@@ -1,0 +1,20 @@
+{
+  "id": "20260416T074913-4422cb24",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-3",
+  "event": "reopened",
+  "commands": [
+    {
+      "command": "reopen task",
+      "status": "passed",
+      "output": "PR CI exposed a timezone-dependent failure in GitHubTokenPoolTest under UTC; reopen phase 3 to repair and reverify the GitHub test slice."
+    }
+  ],
+  "result": "passed",
+  "evidence": [
+    "PR CI exposed a timezone-dependent failure in GitHubTokenPoolTest under UTC; reopen phase 3 to repair and reverify the GitHub test slice."
+  ],
+  "error_fingerprint": null,
+  "next_action": "plan or run",
+  "timestamp": "2026-04-16T07:49:13+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T074918-e6a2ba2e.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T074918-e6a2ba2e.json
@@ -1,0 +1,18 @@
+{
+  "id": "20260416T074918-e6a2ba2e",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-3",
+  "event": "phase_completion",
+  "commands": [
+    {
+      "command": "phase completion",
+      "status": "passed",
+      "output": "git-ranker/src/test/java/com/gitranker/api/infrastructure/github/token/GitHubTokenPoolTest.java"
+    }
+  ],
+  "result": "passed",
+  "evidence": [],
+  "error_fingerprint": null,
+  "next_action": "verify",
+  "timestamp": "2026-04-16T07:49:18+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T074928-f23cfd46.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T074928-f23cfd46.json
@@ -1,0 +1,23 @@
+{
+  "id": "20260416T074928-f23cfd46",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-3",
+  "event": "verification",
+  "commands": [
+    {
+      "command": "cd git-ranker && ./gradlew test --tests 'com.gitranker.api.infrastructure.github.*'",
+      "status": "passed",
+      "output": "> Task :compileJava UP-TO-DATE\n> Task :processResources UP-TO-DATE\n> Task :classes UP-TO-DATE\n> Task :compileTestJava UP-TO-DATE\n> Task :processTestResources NO-SOURCE\n> Task :testClasses UP-TO-DATE\n> Task :test\n\nBUILD SUCCESSFUL in 2s\n4 actionable tasks: 1 executed, 3 up-to-date\nConsider enabling configuration cache to speed up this build: https://docs.gradle.org/9.2.1/userguide/configuration_cache_enabling.html\n\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended"
+    },
+    {
+      "command": "cd git-ranker && ./gradlew test",
+      "status": "passed",
+      "output": "> Task :compileJava UP-TO-DATE\n> Task :processResources UP-TO-DATE\n> Task :classes UP-TO-DATE\n> Task :compileTestJava UP-TO-DATE\n> Task :processTestResources NO-SOURCE\n> Task :testClasses UP-TO-DATE\n> Task :test\n\nBUILD SUCCESSFUL in 2s\n4 actionable tasks: 1 executed, 3 up-to-date\nConsider enabling configuration cache to speed up this build: https://docs.gradle.org/9.2.1/userguide/configuration_cache_enabling.html\n\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended"
+    }
+  ],
+  "result": "passed",
+  "evidence": [],
+  "error_fingerprint": null,
+  "next_action": "review",
+  "timestamp": "2026-04-16T07:49:28+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T075010-e7076ff9.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T075010-e7076ff9.json
@@ -1,0 +1,20 @@
+{
+  "id": "20260416T075010-e7076ff9",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-3",
+  "event": "review_ready",
+  "commands": [
+    {
+      "command": "review gate",
+      "status": "passed",
+      "output": "latest passed verification: 20260416T074928-f23cfd46"
+    }
+  ],
+  "result": "passed",
+  "evidence": [
+    "PR CI follow-up fixed a UTC-dependent GitHubTokenPoolTest failure and passed local UTC clean test verification."
+  ],
+  "error_fingerprint": null,
+  "next_action": "user validation",
+  "timestamp": "2026-04-16T07:50:10+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T081813-fb41cea4.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T081813-fb41cea4.json
@@ -1,0 +1,20 @@
+{
+  "id": "20260416T081813-fb41cea4",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-3",
+  "event": "reopened",
+  "commands": [
+    {
+      "command": "reopen task",
+      "status": "passed",
+      "output": "PR review follow-up reopened phase-3 to incorporate actionable Codex and CodeRabbit test feedback."
+    }
+  ],
+  "result": "passed",
+  "evidence": [
+    "PR review follow-up reopened phase-3 to incorporate actionable Codex and CodeRabbit test feedback."
+  ],
+  "error_fingerprint": null,
+  "next_action": "plan or run",
+  "timestamp": "2026-04-16T08:18:13+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T081821-1c5162d8.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T081821-1c5162d8.json
@@ -1,0 +1,22 @@
+{
+  "id": "20260416T081821-1c5162d8",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-3",
+  "event": "phase_kickoff",
+  "commands": [
+    {
+      "command": "phase kickoff",
+      "status": "passed",
+      "output": "kickoff recorded for phase-3"
+    }
+  ],
+  "result": "passed",
+  "evidence": [
+    "required_reads: workflows/tasks/task-gitranker-core-loop-unit-tests/spec.md, git-ranker/src/main/java/com/gitranker/api/infrastructure/github/, git-ranker/src/test/java/",
+    "starting_points: Read the locked spec for task-gitranker-core-loop-unit-tests., Inspect the active phase goal: Add exhaustive GitHub collection and error translation unit tests, then confirm the full git-ranker unit-test baseline stays green., Confirm allowed write paths and acceptance commands before editing.",
+    "completion_signal: phase-3 acceptance commands pass"
+  ],
+  "error_fingerprint": null,
+  "next_action": "start phase",
+  "timestamp": "2026-04-16T08:18:21+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T081830-d02f2d4f.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T081830-d02f2d4f.json
@@ -1,0 +1,18 @@
+{
+  "id": "20260416T081830-d02f2d4f",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-3",
+  "event": "phase_completion",
+  "commands": [
+    {
+      "command": "phase completion",
+      "status": "passed",
+      "output": "git-ranker/src/test/java/com/gitranker/api/batch/listener/UserScoreCalculationSkipListenerTest.java, git-ranker/src/test/java/com/gitranker/api/batch/metrics/BatchMetricsTest.java, git-ranker/src/test/java/com/gitranker/api/batch/processor/ScoreRecalculationProcessorTest.java, git-ranker/src/test/java/com/gitranker/api/domain/auth/service/AuthServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/log/ActivityLogOrchestratorTest.java, git-ranker/src/test/java/com/gitranker/api/domain/log/ActivityLogServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/ranking/RankingServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/user/UserTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/GitHubApiMetricsTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/GitHubGraphQLClientTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/token/GitHubTokenPoolTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/token/TokenStateTest.java"
+    }
+  ],
+  "result": "passed",
+  "evidence": [],
+  "error_fingerprint": null,
+  "next_action": "verify",
+  "timestamp": "2026-04-16T08:18:30+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T081834-ecd3d697.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T081834-ecd3d697.json
@@ -1,0 +1,18 @@
+{
+  "id": "20260416T081834-ecd3d697",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-3",
+  "event": "verification",
+  "commands": [
+    {
+      "command": "cd git-ranker && ./gradlew test --tests 'com.gitranker.api.infrastructure.github.*'",
+      "status": "failed",
+      "output": "Exception in thread \"main\" java.io.FileNotFoundException: /Users/hyoseok/.gradle/wrapper/dists/gradle-9.2.1-bin/2t0n5ozlw9xmuyvbp7dnzaxug/gradle-9.2.1-bin.zip.lck (Operation not permitted)\n\tat java.base/java.io.RandomAccessFile.open0(Native Method)\n\tat java.base/java.io.RandomAccessFile.open(RandomAccessFile.java:338)\n\tat java.base/java.io.RandomAccessFile.<init>(RandomAccessFile.java:257)\n\tat java.base/java.io.RandomAccessFile.<init>(RandomAccessFile.java:211)\n\tat org.gradle.wrapper.GradleWrapperMain.main(SourceFile:67)"
+    }
+  ],
+  "result": "failed",
+  "evidence": [],
+  "error_fingerprint": "verification:phase-3:cd git-ranker && ./gradlew test --tests 'com.gitranker.api.infrastructure.github.*'",
+  "next_action": "repair",
+  "timestamp": "2026-04-16T08:18:34+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T081905-b1928d47.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T081905-b1928d47.json
@@ -1,0 +1,20 @@
+{
+  "id": "20260416T081905-b1928d47",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-3",
+  "event": "reopened",
+  "commands": [
+    {
+      "command": "reopen task",
+      "status": "passed",
+      "output": "Retry phase-3 verification after sandbox blocked Gradle wrapper lock access during workflow verify."
+    }
+  ],
+  "result": "passed",
+  "evidence": [
+    "Retry phase-3 verification after sandbox blocked Gradle wrapper lock access during workflow verify."
+  ],
+  "error_fingerprint": null,
+  "next_action": "plan or run",
+  "timestamp": "2026-04-16T08:19:05+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T081909-3984baf2.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T081909-3984baf2.json
@@ -1,0 +1,22 @@
+{
+  "id": "20260416T081909-3984baf2",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-3",
+  "event": "phase_kickoff",
+  "commands": [
+    {
+      "command": "phase kickoff",
+      "status": "passed",
+      "output": "kickoff recorded for phase-3"
+    }
+  ],
+  "result": "passed",
+  "evidence": [
+    "required_reads: workflows/tasks/task-gitranker-core-loop-unit-tests/spec.md, git-ranker/src/main/java/com/gitranker/api/infrastructure/github/, git-ranker/src/test/java/",
+    "starting_points: Read the locked spec for task-gitranker-core-loop-unit-tests., Inspect the active phase goal: Add exhaustive GitHub collection and error translation unit tests, then confirm the full git-ranker unit-test baseline stays green., Confirm allowed write paths and acceptance commands before editing.",
+    "completion_signal: phase-3 acceptance commands pass"
+  ],
+  "error_fingerprint": null,
+  "next_action": "start phase",
+  "timestamp": "2026-04-16T08:19:09+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T081920-336565ba.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T081920-336565ba.json
@@ -1,0 +1,18 @@
+{
+  "id": "20260416T081920-336565ba",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-3",
+  "event": "phase_completion",
+  "commands": [
+    {
+      "command": "phase completion",
+      "status": "passed",
+      "output": "git-ranker/src/test/java/com/gitranker/api/batch/listener/UserScoreCalculationSkipListenerTest.java, git-ranker/src/test/java/com/gitranker/api/batch/metrics/BatchMetricsTest.java, git-ranker/src/test/java/com/gitranker/api/batch/processor/ScoreRecalculationProcessorTest.java, git-ranker/src/test/java/com/gitranker/api/domain/auth/service/AuthServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/log/ActivityLogOrchestratorTest.java, git-ranker/src/test/java/com/gitranker/api/domain/log/ActivityLogServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/ranking/RankingServiceTest.java, git-ranker/src/test/java/com/gitranker/api/domain/user/UserTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/GitHubApiMetricsTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/GitHubGraphQLClientTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/token/GitHubTokenPoolTest.java, git-ranker/src/test/java/com/gitranker/api/infrastructure/github/token/TokenStateTest.java"
+    }
+  ],
+  "result": "passed",
+  "evidence": [],
+  "error_fingerprint": null,
+  "next_action": "verify",
+  "timestamp": "2026-04-16T08:19:20+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T081946-7f67b0e4.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T081946-7f67b0e4.json
@@ -1,0 +1,23 @@
+{
+  "id": "20260416T081946-7f67b0e4",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-3",
+  "event": "verification",
+  "commands": [
+    {
+      "command": "cd git-ranker && ./gradlew test --tests 'com.gitranker.api.infrastructure.github.*'",
+      "status": "passed",
+      "output": "> Task :compileJava UP-TO-DATE\n> Task :processResources UP-TO-DATE\n> Task :classes UP-TO-DATE\n> Task :compileTestJava UP-TO-DATE\n> Task :processTestResources NO-SOURCE\n> Task :testClasses UP-TO-DATE\n> Task :test\n\nBUILD SUCCESSFUL in 2s\n4 actionable tasks: 1 executed, 3 up-to-date\nConsider enabling configuration cache to speed up this build: https://docs.gradle.org/9.2.1/userguide/configuration_cache_enabling.html\n\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended"
+    },
+    {
+      "command": "cd git-ranker && ./gradlew test",
+      "status": "passed",
+      "output": "> Task :compileJava UP-TO-DATE\n> Task :processResources UP-TO-DATE\n> Task :classes UP-TO-DATE\n> Task :compileTestJava UP-TO-DATE\n> Task :processTestResources NO-SOURCE\n> Task :testClasses UP-TO-DATE\n> Task :test\n\nBUILD SUCCESSFUL in 2s\n4 actionable tasks: 1 executed, 3 up-to-date\nConsider enabling configuration cache to speed up this build: https://docs.gradle.org/9.2.1/userguide/configuration_cache_enabling.html\n\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended"
+    }
+  ],
+  "result": "passed",
+  "evidence": [],
+  "error_fingerprint": null,
+  "next_action": "review",
+  "timestamp": "2026-04-16T08:19:46+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T081951-53ffd56f.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/runs/20260416T081951-53ffd56f.json
@@ -1,0 +1,20 @@
+{
+  "id": "20260416T081951-53ffd56f",
+  "task_id": "task-gitranker-core-loop-unit-tests",
+  "phase_id": "phase-3",
+  "event": "review_ready",
+  "commands": [
+    {
+      "command": "review gate",
+      "status": "passed",
+      "output": "latest passed verification: 20260416T081946-7f67b0e4"
+    }
+  ],
+  "result": "passed",
+  "evidence": [
+    "Addressed actionable PR review feedback in git-ranker tests, reverified phase-3 with workflow evidence, and confirmed full ./gradlew test is green."
+  ],
+  "error_fingerprint": null,
+  "next_action": "user validation",
+  "timestamp": "2026-04-16T08:19:51+00:00"
+}

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/spec.md
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/spec.md
@@ -1,0 +1,72 @@
+# Strengthen git-ranker core loop unit tests
+
+- Task ID: `task-gitranker-core-loop-unit-tests`
+- Primary Repo: `git-ranker`
+- Status: `draft`
+
+## Request
+
+- `git-ranker`의 물리적 피드백 및 검증 루프에 대해 현재 구현된 로직을 기준으로 unit 테스트를 보강한다.
+- 이미 존재하는 테스트 코드는 다시 검토해 개선하거나 추가해야 할 케이스를 반영한다.
+- happy path만이 아니라 예외 케이스, 비즈니스 로직 검증, 경계값, fallback, side effect, non-interaction까지 놓치기 쉬운 부분을 세분화해 테스트로 고정한다.
+
+## Problem
+
+- 현재 `git-ranker`의 test baseline은 일부 service 중심으로만 구성되어 있어 핵심 피드백/검증 루프를 이루는 value object, batch, GitHub infra, orchestration 로직의 회귀 위험이 남아 있다.
+- 기존 테스트도 happy path 위주인 곳이 있어 예외 번역, 경계값, null/empty fallback, metric 또는 repository side effect 누락 여부를 충분히 검증하지 못한다.
+- 이 상태에서는 도메인 규칙이나 배치 루프를 수정할 때 의도하지 않은 동작 변화가 CI에서 충분히 드러나지 않을 수 있다.
+
+## Goals
+
+- 기존 unit 테스트를 재검토해 약한 assertion, 누락된 분기, 빠진 예외 케이스를 보강한다.
+- 핵심 피드백/검증 루프에 해당하는 미테스트 로직에 대해 JUnit 5 + Mockito 중심의 좁은 unit 테스트를 추가한다.
+- 각 대상 로직에 대해 정상 흐름, 경계값, null/empty/default, 예외 번역, side effect, non-interaction, time-dependent branch, mapping/invariant를 검증한다.
+- 최종적으로 `git-ranker`에서 `./gradlew test`가 green 이어야 한다.
+
+## Non-goals
+
+- controller, security filter, `GlobalExceptionHandler`, config, repository integration, Micrometer wiring 테스트는 이번 작업에 포함하지 않는다.
+- JaCoCo, coverage gate, CI workflow, Gradle dependency 변경은 이번 작업에 포함하지 않는다.
+- production API, endpoint, batch schedule, 메시지 key, runtime contract 변경은 목표가 아니다.
+- 테스트 고립이 막히는 경우를 제외하고 production code 리팩터링 자체를 이번 작업의 주목적으로 삼지 않는다.
+
+## Constraints
+
+- root `AGENTS.md` workflow 계약을 따른다. 승인된 spec 없이 phase 실행이나 구현을 시작하지 않는다.
+- task state와 phase state는 `python3 scripts/workflow.py ...` 명령으로만 전이한다.
+- 구현 변경에는 대응 테스트가 필요하며, 이번 작업은 `test_policy.mode=require_tests`를 따른다.
+- canonical plan은 `workflows/tasks/task-gitranker-core-loop-unit-tests/phases.json` 하나다.
+- 테스트 수준은 `JUnit 5 + Mockito` 중심의 좁은 unit로 고정하고 `@WebMvcTest`, `@SpringBootTest`는 쓰지 않는다.
+- 수정은 active phase의 `allowed_write_paths` 안에서만 수행한다.
+
+## Acceptance
+
+- 기존 테스트 보강과 신규 핵심 루프 테스트가 `src/test/java` 아래에 추가되어 있다.
+- 기존 테스트 보강 범위에는 최소한 `ActivityLogServiceTest`, `AuthServiceTest`, `UserPersistenceServiceTest`, `UserRegistrationServiceTest`, `UserRefreshServiceTest`, `UserQueryServiceTest`, `RankingServiceTest`, `RankingRecalculationServiceTest`, `BadgeServiceTest`, `BadgeFormatterTest`, `SvgBadgeRendererTest`, `TimeUtilsTest`, `UserDeletionServiceTest`가 포함된다.
+- 신규 테스트 범위에는 최소한 `ActivityStatistics`, `Score`, `RankInfo`, `User`, `ActivityLog`, `ActivityLogOrchestrator`, batch strategy/processor/listener/tasklet/reader/writer/scheduler, GitHub service/mapper/error handler/client/token/query/dto 계열이 포함된다.
+- 테스트는 happy path뿐 아니라 예외, 경계값, 비즈니스 규칙, fallback, side effect, non-interaction을 검증한다.
+- `git-ranker`에서 `./gradlew test`가 통과한다.
+
+## Socratic Clarification Log
+
+- Q: 이번 task의 테스트 범위를 어디까지 잠글까요?
+- A: 핵심 피드백/검증 루프를 우선 완결하고, trivial DTO/config/entity/interface 전수 테스트는 제외합니다.
+- Decision: 핵심 피드백/검증 루프와 그 주변의 기존 unit test 보강만 이번 task 범위로 잠근다.
+
+- Q: 테스트 수준은 어디까지 허용할까요?
+- A: 좁은 unit 중심으로 가고 외부 I/O와 전체 Spring context 부팅은 피합니다.
+- Decision: `JUnit 5 + Mockito` 중심의 좁은 unit test로 고정한다.
+
+- Q: 기존 테스트 코드도 다시 검토하고 보강할까요?
+- A: 네. 이미 있는 테스트도 다시 확인해 개선하거나 추가해야 할 케이스를 반영합니다.
+- Decision: 신규 테스트 추가와 함께 기존 test file의 약한 assertion과 누락 분기를 보강한다.
+
+- Q: happy path만 작성하면 되나요?
+- A: 아니요. 예외 케이스, 필요한 비즈니스 로직 검증, 놓치기 쉬운 케이스까지 모두 고려해 세분화합니다.
+- Decision: 각 대상 로직은 정상 흐름, 예외, 경계값, fallback, side effect, non-interaction, invariant를 포함해 테스트한다.
+
+## Approval
+
+- Actor: `user`
+- Timestamp: `2026-04-16T05:47:28+00:00`
+- Note: User approved the detailed unit-test implementation plan in chat.

--- a/workflows/tasks/task-gitranker-core-loop-unit-tests/task.json
+++ b/workflows/tasks/task-gitranker-core-loop-unit-tests/task.json
@@ -1,0 +1,79 @@
+{
+  "id": "task-gitranker-core-loop-unit-tests",
+  "title": "Strengthen git-ranker core loop unit tests",
+  "state": "review_ready",
+  "primary_repo": "git-ranker",
+  "created_at": "2026-04-16T05:46:36+00:00",
+  "approved_at": "2026-04-16T05:47:28+00:00",
+  "approval": {
+    "actor": "user",
+    "note": "User approved the detailed unit-test implementation plan in chat.",
+    "timestamp": "2026-04-16T05:47:28+00:00"
+  },
+  "active_phase_id": "phase-3",
+  "latest_run_id": "20260416T081951-53ffd56f",
+  "last_verified_run_id": "20260416T081946-7f67b0e4",
+  "blocked_reason": null,
+  "user_validated": false,
+  "user_validation_note": null,
+  "intake": {
+    "request_summary": "`git-ranker`의 물리적 피드백 및 검증 루프에 대해 현재 구현된 로직을 기준으로 unit 테스트를 보강한다. 이미 존재하는 테스트 코드는 다시 검토해 개선하거나 추가해야 할 케이스를 반영한다. happy path만이 아니라 예외 케이스, 비즈니스 로직 검증, 경계값, fallback, side effect, non-interaction까지 놓치기 쉬운 부분을 세분화해 테스트로 고정한다.",
+    "problem_summary": "현재 `git-ranker`의 test baseline은 일부 service 중심으로만 구성되어 있어 핵심 피드백/검증 루프를 이루는 value object, batch, GitHub infra, orchestration 로직의 회귀 위험이 남아 있다. 기존 테스트도 happy path 위주인 곳이 있어 예외 번역, 경계값, null/empty fallback, metric 또는 repository side effect 누락 여부를 충분히 검증하지 못한다. 이 상태에서는 도메인 규칙이나 배치 루프를 수정할 때 의도하지 않은 동작 변화가 CI에서 충분히 드러나지 않을 수 있다.",
+    "goals": [
+      "기존 unit 테스트를 재검토해 약한 assertion, 누락된 분기, 빠진 예외 케이스를 보강한다.",
+      "핵심 피드백/검증 루프에 해당하는 미테스트 로직에 대해 JUnit 5 + Mockito 중심의 좁은 unit 테스트를 추가한다.",
+      "각 대상 로직에 대해 정상 흐름, 경계값, null/empty/default, 예외 번역, side effect, non-interaction, time-dependent branch, mapping/invariant를 검증한다.",
+      "최종적으로 `git-ranker`에서 `./gradlew test`가 green 이어야 한다."
+    ],
+    "non_goals": [
+      "controller, security filter, `GlobalExceptionHandler`, config, repository integration, Micrometer wiring 테스트는 이번 작업에 포함하지 않는다.",
+      "JaCoCo, coverage gate, CI workflow, Gradle dependency 변경은 이번 작업에 포함하지 않는다.",
+      "production API, endpoint, batch schedule, 메시지 key, runtime contract 변경은 목표가 아니다.",
+      "테스트 고립이 막히는 경우를 제외하고 production code 리팩터링 자체를 이번 작업의 주목적으로 삼지 않는다."
+    ],
+    "constraints": [
+      "root `AGENTS.md` workflow 계약을 따른다. 승인된 spec 없이 phase 실행이나 구현을 시작하지 않는다.",
+      "task state와 phase state는 `python3 scripts/workflow.py ...` 명령으로만 전이한다.",
+      "구현 변경에는 대응 테스트가 필요하며, 이번 작업은 `test_policy.mode=require_tests`를 따른다.",
+      "canonical plan은 `workflows/tasks/task-gitranker-core-loop-unit-tests/phases.json` 하나다.",
+      "테스트 수준은 `JUnit 5 + Mockito` 중심의 좁은 unit로 고정하고 `@WebMvcTest`, `@SpringBootTest`는 쓰지 않는다.",
+      "수정은 active phase의 `allowed_write_paths` 안에서만 수행한다."
+    ],
+    "acceptance": [
+      "기존 테스트 보강과 신규 핵심 루프 테스트가 `src/test/java` 아래에 추가되어 있다.",
+      "기존 테스트 보강 범위에는 최소한 `ActivityLogServiceTest`, `AuthServiceTest`, `UserPersistenceServiceTest`, `UserRegistrationServiceTest`, `UserRefreshServiceTest`, `UserQueryServiceTest`, `RankingServiceTest`, `RankingRecalculationServiceTest`, `BadgeServiceTest`, `BadgeFormatterTest`, `SvgBadgeRendererTest`, `TimeUtilsTest`, `UserDeletionServiceTest`가 포함된다.",
+      "신규 테스트 범위에는 최소한 `ActivityStatistics`, `Score`, `RankInfo`, `User`, `ActivityLog`, `ActivityLogOrchestrator`, batch strategy/processor/listener/tasklet/reader/writer/scheduler, GitHub service/mapper/error handler/client/token/query/dto 계열이 포함된다.",
+      "테스트는 happy path뿐 아니라 예외, 경계값, 비즈니스 규칙, fallback, side effect, non-interaction을 검증한다.",
+      "`git-ranker`에서 `./gradlew test`가 통과한다."
+    ],
+    "clarifications": [
+      {
+        "question": "이번 task의 테스트 범위를 어디까지 잠글까요?",
+        "answer": "핵심 피드백/검증 루프를 우선 완결하고, trivial DTO/config/entity/interface 전수 테스트는 제외합니다.",
+        "decision": "핵심 피드백/검증 루프와 그 주변의 기존 unit test 보강만 이번 task 범위로 잠근다.",
+        "resolved": true
+      },
+      {
+        "question": "테스트 수준은 어디까지 허용할까요?",
+        "answer": "좁은 unit 중심으로 가고 외부 I/O와 전체 Spring context 부팅은 피합니다.",
+        "decision": "`JUnit 5 + Mockito` 중심의 좁은 unit test로 고정한다.",
+        "resolved": true
+      },
+      {
+        "question": "기존 테스트 코드도 다시 검토하고 보강할까요?",
+        "answer": "네. 이미 있는 테스트도 다시 확인해 개선하거나 추가해야 할 케이스를 반영합니다.",
+        "decision": "신규 테스트 추가와 함께 기존 test file의 약한 assertion과 누락 분기를 보강한다.",
+        "resolved": true
+      },
+      {
+        "question": "happy path만 작성하면 되나요?",
+        "answer": "아니요. 예외 케이스, 필요한 비즈니스 로직 검증, 놓치기 쉬운 케이스까지 모두 고려해 세분화합니다.",
+        "decision": "각 대상 로직은 정상 흐름, 예외, 경계값, fallback, side effect, non-interaction, invariant를 포함해 테스트한다.",
+        "resolved": true
+      }
+    ]
+  },
+  "contract_version": 1,
+  "kickoff_required_for_phase": null,
+  "last_kickoff_run_id": "20260416T081909-3984baf2"
+}


### PR DESCRIPTION
## Summary
- workflow repo에 `task-gitranker-core-loop-unit-tests` control-plane artifact를 추가했습니다.
- backend `git-ranker` issue #88 / PR #89에서 수행된 core loop unit test 보강 작업에 대응하는 spec, phases, runs evidence를 workflow repo에 보존합니다.
- 이 PR은 workflow artifact만 다루며 backend source code나 submodule pointer는 변경하지 않습니다.

## Linked Issue
- Closes #99
- Related backend issue: alexization/git-ranker#88
- Related backend PR: alexization/git-ranker#89
- No-issue reason: 없음

## How
- `workflows/tasks/task-gitranker-core-loop-unit-tests/spec.md`에 승인된 요구사항과 소크라테스 clarification log를 기록했습니다.
- `task.json`, `phases.json`, `runs/*.json`을 함께 추가해 approve -> phase execution -> verification -> review_ready 흐름을 workflow repo에 고정했습니다.
- artifact state는 `review_ready`이며 latest passed verification run은 `20260416T081946-7f67b0e4`입니다.

## Validation Summary
- `python3 scripts/workflow.py doctor`
- `python3 scripts/workflow.py hook pre_commit --task-id task-gitranker-core-loop-unit-tests --phase-id phase-3 --staged`
- `python3 scripts/workflow.py hook pre_push --command-text "git push origin codex/publish-core-loop-task-artifact"`
- backend test execution evidence is preserved in `workflows/tasks/task-gitranker-core-loop-unit-tests/runs/*.json` and corresponds to `alexization/git-ranker` PR #89.

## Reviewer Focus
- task artifact가 backend 작업 범위를 정확히 반영하는지
- phase/run evidence가 `review_ready` state와 일관적인지
- workflow repo와 backend repo의 역할 경계가 PR 본문과 artifact에서 명확한지

## Impact / Risks
- 새 라이브러리, 외부 서비스, 스키마, 설정, 환경 변수, 마이그레이션: 없음
- 사용자나 운영에 영향이 있으면 적어 주세요: workflow repo에서 backend unit-test 작업의 control-plane 추적성이 생깁니다.
- 배포, 롤백, 커뮤니케이션 시 주의점이 있으면 적어 주세요: backend 구현 세부사항은 계속 `alexization/git-ranker` PR #89에서 확인해야 합니다.
- 남아 있는 리스크와 후속 작업: 이 task는 아직 `completed`가 아니라 `review_ready`이므로, 사용자 validation 이후 closeout artifact가 추가될 수 있습니다.
