### PR TITLE
chore: 프런트 정리 반영 - gitlink·베이스라인·훅 동기화

### DIFF
--- a/.claude/hooks/block-dangerous.sh
+++ b/.claude/hooks/block-dangerous.sh
@@ -12,12 +12,16 @@ except Exception:
 cmd = (data.get("tool_input") or {}).get("command") or ""
 
 BLOCKED_PATTERNS = [
-    r"rm\s+-rf",
+    # recursive rm (플래그 순서·분리·long-form 무관): -rf, -fr, -r -f, --recursive ...
+    r"rm\s+(?:\S+\s+)*(?:-[a-zA-Z]*[rR][a-zA-Z]*|--recursive)\b",
     r"git\s+reset\s+--hard",
     r"git\s+checkout\s+--",
-    r"git\s+clean\s+-fd",
+    # git clean with force: -fd, -df, -f -d, --force ...
+    r"git\s+clean\s+(?:\S+\s+)*(?:-[a-zA-Z]*f[a-zA-Z]*|--force)\b",
     r"git\s+push(?:\s+\S+)*\s+--force(?:\S+)?",
     r"git\s+push(?:\s+\S+)*\s+-[A-Za-z]*f[A-Za-z]*",
+    # force push via + refspec: git push origin +main
+    r"git\s+push(?:\s+\S+)*\s+\+\S+",
     r"DROP\s+TABLE",
     r"TRUNCATE\s+TABLE",
 ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,13 +15,13 @@
 
 - 비자명한 구현 작업은 Plan 모드로 계획을 세우고 사용자 승인 후 구현한다.
 - 요구사항이 모호하면 구현 전에 AskUserQuestion으로 해소한다. 추측으로 범위를 넓히지 않는다.
-- 구현 코드 변경에는 대응하는 테스트 변경을 함께 제출한다. 테스트를 생략하면 그 근거를 커밋/PR에 명시한다.
+- 구현 코드 변경에는 대응하는 테스트 변경을 함께 제출한다(`git-ranker`는 JUnit, `git-ranker-client`는 vitest 순수 로직 단위 테스트 — 컴포넌트/E2E는 미도입). 테스트 harness가 없는 영역(예: 프런트 UI 컴포넌트)은 테스트를 생략하고 그 근거를 커밋/PR에 명시한다.
 - 작업 완료 보고 전에 해당 저장소의 검증 베이스라인을 통과시킨다.
 
 ## 검증 베이스라인
 
 - `git-ranker`: `./gradlew test` → `./gradlew build`
-- `git-ranker-client`: `npm run lint` → `npm run typecheck` → `npm run build` (자세한 계약은 `git-ranker-client/docs/verification-contract.md`)
+- `git-ranker-client`: `npm run lint` → `npm run typecheck` → `npm run test` → `npm run build` (자세한 계약은 `git-ranker-client/docs/verification-contract.md`)
 
 ## Git 규약
 


### PR DESCRIPTION
## 개요

`git-ranker-client`의 감사 정리(alexization/git-ranker-client#10)를 umbrella에 반영한다.

## 변경

- `git-ranker-client` gitlink를 정리 커밋으로 갱신
- 검증 베이스라인에 `npm run test` 단계 반영 (CLAUDE.md)
- 테스트 정책 문구를 서브모듈 실태(vitest 순수 로직 단위 테스트, 컴포넌트/E2E 미도입)와 정합화
- `block-dangerous` 훅을 서브모듈과 동일하게 보강 (byte-identical)

## 병합 순서 주의

gitlink가 클라이언트 feature 브랜치 tip(`ab898d5`)을 가리킨다. **클라이언트 PR(#10)을 먼저 merge**한 뒤 이 PR을 처리하는 것을 권장한다.

- 클라이언트가 merge-commit / fast-forward로 merge되면 `ab898d5`가 develop에 남아 gitlink가 그대로 유효하다.
- 클라이언트가 squash-merge되면 `ab898d5`가 develop에 남지 않으므로, `/sync`로 gitlink를 develop 최신으로 재지정해야 한다.
